### PR TITLE
ci: add PR check workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -33,4 +33,6 @@ jobs:
         run: npm run test -- --passWithNoTests
 
       - name: Build
-        run: npm run build
+        # Use npx next build directly to skip postbuild script
+        # (postbuild runs package:server which requires pkg binary)
+        run: npx next build

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,29 @@
+name: 'PR Check'
+
+on:
+  pull_request:
+    branches: [develop]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test -- --passWithNoTests
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,6 +7,12 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    env:
+      # Existing astro_utils tests depend on Europe/Paris timezone due to
+      # a variable shadowing bug in calc_jd() (astro_utils.ts:503).
+      # The `new Date()` constructor interprets UTC components as local time,
+      # so test expectations only match in the upstream developer's timezone.
+      TZ: Europe/Paris
     steps:
       - uses: actions/checkout@v4
 
@@ -14,6 +20,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          # npm cache requires a lock file, but package-lock.json is
+          # gitignored in upstream. Using npm install instead of npm ci.
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,10 +14,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Lint
         run: npm run lint

--- a/src/lib/witmotion/ConnectToBluetooth.ts
+++ b/src/lib/witmotion/ConnectToBluetooth.ts
@@ -51,28 +51,36 @@ export class UsingBluetooth implements DeviceInterface {
 
   public accelerometerCalibration = async () => {
     await defaultAccelerometerCalibration(
-      this.writeCharacteristic?.writeValue.bind(this.writeCharacteristic)
+      this.writeCharacteristic?.writeValue.bind(this.writeCharacteristic) as
+        | ((value: ArrayBufferView) => Promise<void>)
+        | undefined
     );
   };
 
   public magnetometerCalibration = async (command: String) => {
     await defaultMagnetometerCalibration(
       command,
-      this.writeCharacteristic?.writeValue.bind(this.writeCharacteristic)
+      this.writeCharacteristic?.writeValue.bind(this.writeCharacteristic) as
+        | ((value: ArrayBufferView) => Promise<void>)
+        | undefined
     );
   };
 
   public dofSelect = async (command: String) => {
     await defaultDofSelect(
       command,
-      this.writeCharacteristic?.writeValue.bind(this.writeCharacteristic)
+      this.writeCharacteristic?.writeValue.bind(this.writeCharacteristic) as
+        | ((value: ArrayBufferView) => Promise<void>)
+        | undefined
     );
   };
 
   public rateSelect = async (command: Number) => {
     await defaultRateSelect(
       command,
-      this.writeCharacteristic?.writeValue.bind(this.writeCharacteristic)
+      this.writeCharacteristic?.writeValue.bind(this.writeCharacteristic) as
+        | ((value: ArrayBufferView) => Promise<void>)
+        | undefined
     );
   };
 }


### PR DESCRIPTION
## Summary
- `develop` ブランチへの PR で自動実行される CI ワークフローを追加
- upstream にはPRトリガーの CI が存在しないため新規追加

## チェック内容
1. **Lint** — `next lint` (ESLint)
2. **Test** — `jest --passWithNoTests` (`TZ=Europe/Paris` で実行)
3. **Build** — `next build` (型エラー検出含む)

## 設計判断
- `npm install` を使用 (`npm ci` は package-lock.json が upstream で gitignore されているため不可)
- npm キャッシュは lock file 不在のため無効
- `TZ=Europe/Paris` を設定 (既存テストが upstream 開発者のTZに依存しているため)
- Tauri ビルド (Rust + 各OS) はPR段階では不要なため含めない
- `ubuntu-latest` のシングルジョブで軽量に

## Test plan
- [x] ローカルで `TZ=Europe/Paris npx jest` → 57 tests passed
- [x] CI が全ステップ (lint, test, build) 通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)