### PR TITLE
fix(i18n): replace hardcoded Dutch text in AstroWeather

### DIFF
--- a/src/components/clouds/AstroWeather.tsx
+++ b/src/components/clouds/AstroWeather.tsx
@@ -1,4 +1,5 @@
 ﻿import React, { useEffect, useState, useContext } from "react";
+import { useTranslation } from "react-i18next";
 import axios from "axios";
 import { ConnectionContext } from "@/stores/ConnectionContext";
 import { getProxyUrl } from "@/lib/get_proxy_url";
@@ -14,15 +15,16 @@ interface WeatherData {
 }
 
 const AstroWeather: React.FC = () => {
+  const { t } = useTranslation();
   const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
-  const [selectedLocation, setSelectedLocation] = useState("50.85,4.35"); // Default: Brussel
+  const [selectedLocation, setSelectedLocation] = useState("50.85,4.35"); // Default: Brussels
 
-  const locations = {
+  const locations: Record<string, string> = {
     Amsterdam: "52.37,4.89",
-    Brussel: "50.85,4.35",
-    Berlijn: "52.52,13.41",
-    Parijs: "48.85,2.35",
-    Londen: "51.51,-0.13",
+    Brussels: "50.85,4.35",
+    Berlin: "52.52,13.41",
+    Paris: "48.85,2.35",
+    London: "51.51,-0.13",
   };
   let connectionCtx = useContext(ConnectionContext);
 
@@ -43,15 +45,18 @@ const AstroWeather: React.FC = () => {
       .then((response) => {
         setWeatherData(response.data as WeatherData);
       })
-      .catch((error) => console.error("Fout bij laden weerdata:", error));
+      .catch((error) =>
+        console.error("Error loading weather data:", error)
+      );
   }, [selectedLocation]);
 
-  if (!weatherData) return <p>🌙 Laden van astronomisch weer...</p>;
+  if (!weatherData)
+    return <p>{t("cAstroWeatherLoading")}</p>;
 
   return (
     <div className="astro-weather">
-      <h2 className="astro-title">Astronomisch Weer op uurbasis</h2>
-      <label htmlFor="location-select">Kies een locatie:</label>
+      <h2 className="astro-title">{t("cAstroWeatherTitle")}</h2>
+      <label htmlFor="location-select">{t("cAstroWeatherSelectLocation")}</label>
       <select
         id="location-select"
         value={selectedLocation}
@@ -65,13 +70,11 @@ const AstroWeather: React.FC = () => {
       </select>
 
       <div className="weather-info">
-        <p>🌤️ Bewolking: {weatherData.hourly.cloudcover[0]}%</p>
-        <p>🌡️ Temperatuur: {weatherData.hourly.temperature_2m[0]}°C</p>
-        <p>💨 Windsnelheid: {weatherData.hourly.windspeed_10m[0]} km/h</p>
-        <p>
-          💧 Luchtvochtigheid: {weatherData.hourly.relative_humidity_2m[0]}%
-        </p>
-        <p>❄️ Dauwpunt: {weatherData.hourly.dewpoint_2m[0]}°C</p>
+        <p>{t("cAstroWeatherCloudCover")} {weatherData.hourly.cloudcover[0]}%</p>
+        <p>{t("cAstroWeatherTemperature")} {weatherData.hourly.temperature_2m[0]}°C</p>
+        <p>{t("cAstroWeatherWindSpeed")} {weatherData.hourly.windspeed_10m[0]} km/h</p>
+        <p>{t("cAstroWeatherHumidity")} {weatherData.hourly.relative_humidity_2m[0]}%</p>
+        <p>{t("cAstroWeatherDewPoint")} {weatherData.hourly.dewpoint_2m[0]}°C</p>
       </div>
     </div>
   );

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -413,5 +413,13 @@
   "cRemoveFromPersonalListButton": "Objekt entfernen",
   "cRemoveFromPersonalListConfirm": "Sind Sie sicher, dass Sie dieses Objekt entfernen möchten?",
   "cRemoveFromPersonalListTitle": "Entfernen Sie das Objekt aus meiner persönlichen Bibliothek",
-  "pMediaMtxNeedOpenPort8888": "Sie müssen jedoch Port 8888 auf dem Proxy Lan Router geöffnet haben."
+  "pMediaMtxNeedOpenPort8888": "Sie müssen jedoch Port 8888 auf dem Proxy Lan Router geöffnet haben.",
+  "cAstroWeatherLoading": "Astronomisches Wetter wird geladen...",
+  "cAstroWeatherTitle": "Stündliches astronomisches Wetter",
+  "cAstroWeatherSelectLocation": "Standort wählen:",
+  "cAstroWeatherCloudCover": "Bewölkung:",
+  "cAstroWeatherTemperature": "Temperatur:",
+  "cAstroWeatherWindSpeed": "Windgeschwindigkeit:",
+  "cAstroWeatherHumidity": "Luftfeuchtigkeit:",
+  "cAstroWeatherDewPoint": "Taupunkt:"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -413,5 +413,13 @@
   "cObjectsRemovePersonal": "Want to remove the Object from your Personal Library?",
   "cRemoveFromPersonalListTitle": "Remove Object from My Personal Library",
   "cRemoveFromPersonalListConfirm": "Are you sure you want to remove this object",
-  "cRemoveFromPersonalListButton": "Remove Object"
+  "cRemoveFromPersonalListButton": "Remove Object",
+  "cAstroWeatherLoading": "Loading astronomical weather...",
+  "cAstroWeatherTitle": "Hourly Astronomical Weather",
+  "cAstroWeatherSelectLocation": "Select a location:",
+  "cAstroWeatherCloudCover": "Cloud cover:",
+  "cAstroWeatherTemperature": "Temperature:",
+  "cAstroWeatherWindSpeed": "Wind speed:",
+  "cAstroWeatherHumidity": "Humidity:",
+  "cAstroWeatherDewPoint": "Dew point:"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -413,5 +413,13 @@
   "cRemoveFromPersonalListButton": "Eliminar objeto",
   "cRemoveFromPersonalListConfirm": "¿Estás seguro de que quieres eliminar este objeto?",
   "cRemoveFromPersonalListTitle": "Eliminar objeto de mi biblioteca personal",
-  "pMediaMtxNeedOpenPort8888": "Pero debe tener el puerto 8888 abierto en el enrutador de LAN proxy."
+  "pMediaMtxNeedOpenPort8888": "Pero debe tener el puerto 8888 abierto en el enrutador de LAN proxy.",
+  "cAstroWeatherLoading": "Cargando clima astronómico...",
+  "cAstroWeatherTitle": "Clima astronómico por hora",
+  "cAstroWeatherSelectLocation": "Seleccionar ubicación:",
+  "cAstroWeatherCloudCover": "Nubosidad:",
+  "cAstroWeatherTemperature": "Temperatura:",
+  "cAstroWeatherWindSpeed": "Velocidad del viento:",
+  "cAstroWeatherHumidity": "Humedad:",
+  "cAstroWeatherDewPoint": "Punto de rocío:"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -413,5 +413,13 @@
   "cRemoveFromPersonalListButton": "Supprimer l'objet",
   "cRemoveFromPersonalListConfirm": "Êtes-vous sûr de vouloir supprimer cet objet",
   "cRemoveFromPersonalListTitle": "Supprimer l'objet de ma bibliothèque personnelle",
-  "pMediaMtxNeedOpenPort8888": "Mais vous devez avoir le port 8888 ouvert sur le routeur LAN proxy."
+  "pMediaMtxNeedOpenPort8888": "Mais vous devez avoir le port 8888 ouvert sur le routeur LAN proxy.",
+  "cAstroWeatherLoading": "Chargement de la météo astronomique...",
+  "cAstroWeatherTitle": "Météo astronomique horaire",
+  "cAstroWeatherSelectLocation": "Choisir un lieu :",
+  "cAstroWeatherCloudCover": "Nébulosité :",
+  "cAstroWeatherTemperature": "Température :",
+  "cAstroWeatherWindSpeed": "Vitesse du vent :",
+  "cAstroWeatherHumidity": "Humidité :",
+  "cAstroWeatherDewPoint": "Point de rosée :"
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -413,5 +413,13 @@
   "cRemoveFromPersonalListButton": "Rimuovere l'oggetto",
   "cRemoveFromPersonalListConfirm": "Sei sicuro di voler rimuovere questo oggetto",
   "cRemoveFromPersonalListTitle": "Rimuovi l'oggetto dalla mia libreria personale",
-  "pMediaMtxNeedOpenPort8888": "Ma devi aprire la porta 8888 sul router LAN proxy."
+  "pMediaMtxNeedOpenPort8888": "Ma devi aprire la porta 8888 sul router LAN proxy.",
+  "cAstroWeatherLoading": "Caricamento meteo astronomico...",
+  "cAstroWeatherTitle": "Meteo astronomico orario",
+  "cAstroWeatherSelectLocation": "Seleziona una località:",
+  "cAstroWeatherCloudCover": "Copertura nuvolosa:",
+  "cAstroWeatherTemperature": "Temperatura:",
+  "cAstroWeatherWindSpeed": "Velocità del vento:",
+  "cAstroWeatherHumidity": "Umidità:",
+  "cAstroWeatherDewPoint": "Punto di rugiada:"
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -413,5 +413,13 @@
   "cObjectsRemovePersonal": "マイライブラリからこの天体を削除しますか？",
   "cRemoveFromPersonalListTitle": "マイライブラリから天体を削除",
   "cRemoveFromPersonalListConfirm": "本当にこの天体を削除しますか？",
-  "cRemoveFromPersonalListButton": "天体を削除"
+  "cRemoveFromPersonalListButton": "天体を削除",
+  "cAstroWeatherLoading": "天文気象データを読み込み中...",
+  "cAstroWeatherTitle": "1時間ごとの天文気象",
+  "cAstroWeatherSelectLocation": "観測地を選択:",
+  "cAstroWeatherCloudCover": "雲量:",
+  "cAstroWeatherTemperature": "気温:",
+  "cAstroWeatherWindSpeed": "風速:",
+  "cAstroWeatherHumidity": "湿度:",
+  "cAstroWeatherDewPoint": "露点:"
 }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -413,5 +413,13 @@
   "cRemoveFromPersonalListButton": "Verwijder object",
   "cRemoveFromPersonalListConfirm": "Weet je zeker dat je dit object wilt verwijderen",
   "cRemoveFromPersonalListTitle": "Verwijder het object uit mijn persoonlijke bibliotheek",
-  "pMediaMtxNeedOpenPort8888": "Maar u moet poort 8888 open hebben op de proxy LAN -router."
+  "pMediaMtxNeedOpenPort8888": "Maar u moet poort 8888 open hebben op de proxy LAN -router.",
+  "cAstroWeatherLoading": "Astronomisch weer laden...",
+  "cAstroWeatherTitle": "Astronomisch weer op uurbasis",
+  "cAstroWeatherSelectLocation": "Kies een locatie:",
+  "cAstroWeatherCloudCover": "Bewolking:",
+  "cAstroWeatherTemperature": "Temperatuur:",
+  "cAstroWeatherWindSpeed": "Windsnelheid:",
+  "cAstroWeatherHumidity": "Luchtvochtigheid:",
+  "cAstroWeatherDewPoint": "Dauwpunt:"
 }

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -413,5 +413,13 @@
   "cRemoveFromPersonalListButton": "Usuń obiekt",
   "cRemoveFromPersonalListConfirm": "Czy na pewno chcesz usunąć ten obiekt",
   "cRemoveFromPersonalListTitle": "Usuń obiekt z mojej osobistej biblioteki",
-  "pMediaMtxNeedOpenPort8888": "Ale musisz otworzyć port 8888 na router Proxy Lan."
+  "pMediaMtxNeedOpenPort8888": "Ale musisz otworzyć port 8888 na router Proxy Lan.",
+  "cAstroWeatherLoading": "Ładowanie pogody astronomicznej...",
+  "cAstroWeatherTitle": "Godzinowa pogoda astronomiczna",
+  "cAstroWeatherSelectLocation": "Wybierz lokalizację:",
+  "cAstroWeatherCloudCover": "Zachmurzenie:",
+  "cAstroWeatherTemperature": "Temperatura:",
+  "cAstroWeatherWindSpeed": "Prędkość wiatru:",
+  "cAstroWeatherHumidity": "Wilgotność:",
+  "cAstroWeatherDewPoint": "Punkt rosy:"
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -413,5 +413,13 @@
   "cRemoveFromPersonalListButton": "Remova o objeto",
   "cRemoveFromPersonalListConfirm": "Tem certeza que deseja remover este objeto",
   "cRemoveFromPersonalListTitle": "Remova o objeto da minha biblioteca pessoal",
-  "pMediaMtxNeedOpenPort8888": "Mas você precisa ter a porta 8888 aberta no roteador proxy LAN."
+  "pMediaMtxNeedOpenPort8888": "Mas você precisa ter a porta 8888 aberta no roteador proxy LAN.",
+  "cAstroWeatherLoading": "Carregando clima astronômico...",
+  "cAstroWeatherTitle": "Clima astronômico por hora",
+  "cAstroWeatherSelectLocation": "Selecionar localização:",
+  "cAstroWeatherCloudCover": "Cobertura de nuvens:",
+  "cAstroWeatherTemperature": "Temperatura:",
+  "cAstroWeatherWindSpeed": "Velocidade do vento:",
+  "cAstroWeatherHumidity": "Umidade:",
+  "cAstroWeatherDewPoint": "Ponto de orvalho:"
 }

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -413,5 +413,13 @@
   "cRemoveFromPersonalListButton": "删除对象",
   "cRemoveFromPersonalListConfirm": "您确定要删除此对象吗",
   "cRemoveFromPersonalListTitle": "从我的个人库中删除对象",
-  "pMediaMtxNeedOpenPort8888": "但是您需要在代理LAN路由器上打开端口8888。"
+  "pMediaMtxNeedOpenPort8888": "但是您需要在代理LAN路由器上打开端口8888。",
+  "cAstroWeatherLoading": "正在加载天文气象数据...",
+  "cAstroWeatherTitle": "逐时天文气象",
+  "cAstroWeatherSelectLocation": "选择位置：",
+  "cAstroWeatherCloudCover": "云量：",
+  "cAstroWeatherTemperature": "温度：",
+  "cAstroWeatherWindSpeed": "风速：",
+  "cAstroWeatherHumidity": "湿度：",
+  "cAstroWeatherDewPoint": "露点："
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded Dutch strings in `AstroWeather.tsx` with `useTranslation()` calls
- Add 8 new `cAstroWeather*` i18n keys to all 10 locale files (de, en, es, fr, it, ja, nl, pl, pt, zh_CN)
- Normalize city names to English (Brussel→Brussels, Berlijn→Berlin, etc.)

## Test plan
- [x] `npm run lint` — no warnings or errors
- [x] `npx next build` — builds successfully
- [x] All locale JSON files are valid
- [ ] CI workflow validates on PR
- [ ] Manual: visit Weather page and verify text displays in selected language

🤖 Generated with [Claude Code](https://claude.com/claude-code)