### PR TITLE
feat(ai): add shooting parameter advisor

### DIFF
--- a/src/__tests__/lib/ai/observation_scorer.test.ts
+++ b/src/__tests__/lib/ai/observation_scorer.test.ts
@@ -11,7 +11,42 @@ import {
   type WeatherCondition,
 } from "@/lib/ai/observation_scorer";
 
-import { DWARF_II, DWARF_3 } from "@/lib/ai/equipment_profiles";
+import {
+  DWARF_II,
+  DWARF_3,
+  getProfileByName,
+} from "@/lib/ai/equipment_profiles";
+
+// ---- getProfileByName ----
+
+describe("getProfileByName", () => {
+  it("returns DWARF II profile", () => {
+    const profile = getProfileByName("DWARF II");
+    expect(profile).toBeDefined();
+    expect(profile!.name).toBe("DWARF II");
+    expect(profile!.apertureMm).toBe(24);
+  });
+
+  it("returns DWARF 3 profile", () => {
+    const profile = getProfileByName("DWARF 3");
+    expect(profile).toBeDefined();
+    expect(profile!.name).toBe("DWARF 3");
+    expect(profile!.apertureMm).toBe(35);
+  });
+
+  it("returns undefined for unknown profile", () => {
+    expect(getProfileByName("DWARF 99")).toBeUndefined();
+    expect(getProfileByName("")).toBeUndefined();
+  });
+
+  it("DWARF II and DWARF 3 have different FOV values", () => {
+    const d2 = getProfileByName("DWARF II")!;
+    const d3 = getProfileByName("DWARF 3")!;
+    // DWARF 3 has longer focal length → narrower FOV
+    expect(d3.fovWidthDeg).toBeLessThan(d2.fovWidthDeg);
+    expect(d3.fovHeightDeg).toBeLessThan(d2.fovHeightDeg);
+  });
+});
 
 // ---- scoreAltitude ----
 

--- a/src/__tests__/lib/ai/observation_scorer.test.ts
+++ b/src/__tests__/lib/ai/observation_scorer.test.ts
@@ -1,0 +1,467 @@
+import {
+  scoreAltitude,
+  scoreMoonImpact,
+  scoreWeather,
+  scoreTargetDifficulty,
+  generateRecommendation,
+  calculateObservationScore,
+  type TargetInfo,
+  type TargetPosition,
+  type MoonCondition,
+  type WeatherCondition,
+} from "@/lib/ai/observation_scorer";
+
+import { DWARF_II, DWARF_3 } from "@/lib/ai/equipment_profiles";
+
+// ---- scoreAltitude ----
+
+describe("scoreAltitude", () => {
+  it("returns 0 for objects at or below horizon", () => {
+    expect(scoreAltitude(0)).toBe(0);
+    expect(scoreAltitude(-10)).toBe(0);
+  });
+
+  it("returns low score for low altitude (0-15 deg)", () => {
+    const score = scoreAltitude(10);
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(30);
+  });
+
+  it("returns moderate score for medium altitude (15-40 deg)", () => {
+    const score = scoreAltitude(30);
+    expect(score).toBeGreaterThanOrEqual(30);
+    expect(score).toBeLessThanOrEqual(85);
+  });
+
+  it("returns high score for high altitude (40-70 deg)", () => {
+    const score = scoreAltitude(55);
+    expect(score).toBeGreaterThanOrEqual(85);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  it("returns 100 for altitude >= 70 deg", () => {
+    expect(scoreAltitude(70)).toBe(100);
+    expect(scoreAltitude(90)).toBe(100);
+  });
+
+  it("is monotonically increasing", () => {
+    let prev = scoreAltitude(-10);
+    for (let alt = 0; alt <= 90; alt += 5) {
+      const current = scoreAltitude(alt);
+      expect(current).toBeGreaterThanOrEqual(prev);
+      prev = current;
+    }
+  });
+});
+
+// ---- scoreMoonImpact ----
+
+describe("scoreMoonImpact", () => {
+  it("returns 100 when moon is below horizon", () => {
+    expect(scoreMoonImpact({ illumination: 1.0, altitudeDeg: -5 }, "galaxies")).toBe(100);
+    expect(scoreMoonImpact({ illumination: 1.0, altitudeDeg: 0 }, "galaxies")).toBe(100);
+  });
+
+  it("returns lower score for bright moon above horizon", () => {
+    const fullMoonHigh: MoonCondition = { illumination: 1.0, altitudeDeg: 60 };
+    const score = scoreMoonImpact(fullMoonHigh, "galaxies");
+    expect(score).toBeLessThan(50);
+  });
+
+  it("returns higher score for dim moon", () => {
+    const crescentMoon: MoonCondition = { illumination: 0.1, altitudeDeg: 30 };
+    const score = scoreMoonImpact(crescentMoon, "galaxies");
+    expect(score).toBeGreaterThan(80);
+  });
+
+  it("clusters are less affected by moonlight than galaxies", () => {
+    const moon: MoonCondition = { illumination: 0.8, altitudeDeg: 45 };
+    const galaxyScore = scoreMoonImpact(moon, "galaxies");
+    const clusterScore = scoreMoonImpact(moon, "clusters");
+    expect(clusterScore).toBeGreaterThan(galaxyScore);
+  });
+
+  it("stars are less affected by moonlight", () => {
+    const moon: MoonCondition = { illumination: 0.8, altitudeDeg: 45 };
+    const nebulaScore = scoreMoonImpact(moon, "nebulae");
+    const starScore = scoreMoonImpact(moon, "stars");
+    expect(starScore).toBeGreaterThan(nebulaScore);
+  });
+});
+
+// ---- scoreWeather ----
+
+describe("scoreWeather", () => {
+  it("returns 100 for clear skies, low humidity, no wind", () => {
+    expect(
+      scoreWeather({ cloudCoverPercent: 0, humidityPercent: 50, windSpeedKmh: 5 })
+    ).toBe(100);
+  });
+
+  it("returns 0 for fully overcast", () => {
+    expect(
+      scoreWeather({ cloudCoverPercent: 100, humidityPercent: 50, windSpeedKmh: 5 })
+    ).toBe(0);
+  });
+
+  it("penalizes high humidity", () => {
+    const lowHumidity = scoreWeather({
+      cloudCoverPercent: 0,
+      humidityPercent: 60,
+      windSpeedKmh: 0,
+    });
+    const highHumidity = scoreWeather({
+      cloudCoverPercent: 0,
+      humidityPercent: 95,
+      windSpeedKmh: 0,
+    });
+    expect(lowHumidity).toBeGreaterThan(highHumidity);
+  });
+
+  it("does not penalize humidity <= 80%", () => {
+    const score = scoreWeather({
+      cloudCoverPercent: 0,
+      humidityPercent: 80,
+      windSpeedKmh: 0,
+    });
+    expect(score).toBe(100);
+  });
+
+  it("penalizes high wind", () => {
+    const calm = scoreWeather({
+      cloudCoverPercent: 0,
+      humidityPercent: 50,
+      windSpeedKmh: 10,
+    });
+    const windy = scoreWeather({
+      cloudCoverPercent: 0,
+      humidityPercent: 50,
+      windSpeedKmh: 40,
+    });
+    expect(calm).toBeGreaterThan(windy);
+  });
+
+  it("does not penalize wind <= 20 km/h", () => {
+    const score = scoreWeather({
+      cloudCoverPercent: 0,
+      humidityPercent: 50,
+      windSpeedKmh: 20,
+    });
+    expect(score).toBe(100);
+  });
+
+  it("never returns negative", () => {
+    const score = scoreWeather({
+      cloudCoverPercent: 100,
+      humidityPercent: 100,
+      windSpeedKmh: 100,
+    });
+    expect(score).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ---- scoreTargetDifficulty ----
+
+describe("scoreTargetDifficulty", () => {
+  it("returns 0 for targets fainter than equipment limit", () => {
+    const target: TargetInfo = {
+      magnitude: 18,
+      angularSizeArcmin: 5,
+      typeCategory: "galaxies",
+    };
+    expect(scoreTargetDifficulty(target, DWARF_II)).toBe(0);
+  });
+
+  it("returns high score for bright targets", () => {
+    const target: TargetInfo = {
+      magnitude: 3,
+      angularSizeArcmin: 60,
+      typeCategory: "nebulae",
+    };
+    expect(scoreTargetDifficulty(target, DWARF_II)).toBeGreaterThanOrEqual(80);
+  });
+
+  it("returns moderate score for dim targets", () => {
+    const target: TargetInfo = {
+      magnitude: 10,
+      angularSizeArcmin: 5,
+      typeCategory: "galaxies",
+    };
+    const score = scoreTargetDifficulty(target, DWARF_II);
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThanOrEqual(60);
+  });
+
+  it("returns 50 for unknown magnitude", () => {
+    const target: TargetInfo = {
+      magnitude: null,
+      angularSizeArcmin: 10,
+      typeCategory: "nebulae",
+    };
+    expect(scoreTargetDifficulty(target, DWARF_II)).toBe(50);
+  });
+
+  it("penalizes objects much larger than FOV", () => {
+    const large: TargetInfo = {
+      magnitude: 5,
+      angularSizeArcmin: 300,
+      typeCategory: "nebulae",
+    };
+    const small: TargetInfo = {
+      magnitude: 5,
+      angularSizeArcmin: 30,
+      typeCategory: "nebulae",
+    };
+    expect(scoreTargetDifficulty(small, DWARF_II)).toBeGreaterThan(
+      scoreTargetDifficulty(large, DWARF_II)
+    );
+  });
+
+  it("penalizes very small objects", () => {
+    const tiny: TargetInfo = {
+      magnitude: 8,
+      angularSizeArcmin: 0.5,
+      typeCategory: "galaxies",
+    };
+    const normal: TargetInfo = {
+      magnitude: 8,
+      angularSizeArcmin: 10,
+      typeCategory: "galaxies",
+    };
+    expect(scoreTargetDifficulty(normal, DWARF_II)).toBeGreaterThan(
+      scoreTargetDifficulty(tiny, DWARF_II)
+    );
+  });
+
+  it("caps planets/moon at 60", () => {
+    const planet: TargetInfo = {
+      magnitude: -2,
+      angularSizeArcmin: 0.5,
+      typeCategory: "moon_planets",
+    };
+    expect(scoreTargetDifficulty(planet, DWARF_II)).toBeLessThanOrEqual(60);
+  });
+
+  it("DWARF 3 can handle fainter targets than DWARF II", () => {
+    const target: TargetInfo = {
+      magnitude: 15,
+      angularSizeArcmin: 3,
+      typeCategory: "galaxies",
+    };
+    // DWARF II limiting mag = 14, so this should be 0
+    expect(scoreTargetDifficulty(target, DWARF_II)).toBe(0);
+    // DWARF 3 limiting mag = 16, so this should be > 0
+    expect(scoreTargetDifficulty(target, DWARF_3)).toBeGreaterThan(0);
+  });
+});
+
+// ---- generateRecommendation ----
+
+describe("generateRecommendation", () => {
+  it("returns excellent recommendation for high overall score", () => {
+    const result = generateRecommendation(
+      85,
+      { altitude: 90, moonImpact: 90, weather: 80, targetDifficulty: 80 },
+      60
+    );
+    expect(result).toContain("Excellent");
+  });
+
+  it("mentions weather for good target with poor weather", () => {
+    const result = generateRecommendation(
+      65,
+      { altitude: 90, moonImpact: 90, weather: 40, targetDifficulty: 80 },
+      60
+    );
+    expect(result).toContain("weather");
+  });
+
+  it("mentions moonlight for good target with bright moon", () => {
+    const result = generateRecommendation(
+      65,
+      { altitude: 90, moonImpact: 40, weather: 80, targetDifficulty: 80 },
+      60
+    );
+    expect(result).toContain("moonlight");
+  });
+
+  it("mentions altitude when target is low", () => {
+    const result = generateRecommendation(
+      65,
+      { altitude: 40, moonImpact: 80, weather: 80, targetDifficulty: 80 },
+      20
+    );
+    expect(result).toContain("altitude");
+  });
+
+  it("mentions below horizon when altitude <= 0", () => {
+    const result = generateRecommendation(
+      10,
+      { altitude: 0, moonImpact: 90, weather: 80, targetDifficulty: 80 },
+      -5
+    );
+    expect(result).toContain("below the horizon");
+  });
+
+  it("mentions too faint when targetDifficulty is 0", () => {
+    const result = generateRecommendation(
+      5,
+      { altitude: 80, moonImpact: 90, weather: 80, targetDifficulty: 0 },
+      60
+    );
+    expect(result).toContain("too faint");
+  });
+});
+
+// ---- calculateObservationScore (integration) ----
+
+describe("calculateObservationScore", () => {
+  const perfectWeather: WeatherCondition = {
+    cloudCoverPercent: 0,
+    humidityPercent: 40,
+    windSpeedKmh: 5,
+  };
+  const noMoon: MoonCondition = { illumination: 0, altitudeDeg: -10 };
+
+  it("returns high score for ideal conditions", () => {
+    const target: TargetInfo = {
+      magnitude: 4,
+      angularSizeArcmin: 30,
+      typeCategory: "nebulae",
+    };
+    const position: TargetPosition = { altitudeDeg: 70, azimuthDeg: 180 };
+
+    const result = calculateObservationScore(
+      target,
+      position,
+      noMoon,
+      perfectWeather,
+      DWARF_II
+    );
+
+    expect(result.overall).toBeGreaterThanOrEqual(80);
+    expect(result.factors.altitude).toBe(100);
+    expect(result.factors.moonImpact).toBe(100);
+    expect(result.factors.weather).toBe(100);
+    expect(result.recommendation).toContain("Excellent");
+  });
+
+  it("returns 0 overall when target is below horizon", () => {
+    const target: TargetInfo = {
+      magnitude: 4,
+      angularSizeArcmin: 30,
+      typeCategory: "nebulae",
+    };
+    const position: TargetPosition = { altitudeDeg: -10, azimuthDeg: 0 };
+
+    const result = calculateObservationScore(
+      target,
+      position,
+      noMoon,
+      perfectWeather,
+      DWARF_II
+    );
+
+    expect(result.factors.altitude).toBe(0);
+    // Altitude weight is 0.3, so even with other factors at 100,
+    // overall max = 0.7 * 100 = 70 (no altitude contribution)
+    expect(result.overall).toBeLessThanOrEqual(70);
+  });
+
+  it("returns low score for poor weather", () => {
+    const target: TargetInfo = {
+      magnitude: 4,
+      angularSizeArcmin: 30,
+      typeCategory: "nebulae",
+    };
+    const position: TargetPosition = { altitudeDeg: 60, azimuthDeg: 180 };
+    const badWeather: WeatherCondition = {
+      cloudCoverPercent: 90,
+      humidityPercent: 95,
+      windSpeedKmh: 40,
+    };
+
+    const result = calculateObservationScore(
+      target,
+      position,
+      noMoon,
+      badWeather,
+      DWARF_II
+    );
+
+    expect(result.factors.weather).toBeLessThan(20);
+    // Weather weight is 0.3, so poor weather pulls down but other
+    // factors (altitude, moon, target) keep overall moderate
+    expect(result.overall).toBeLessThan(80);
+  });
+
+  it("returns lower score with bright full moon", () => {
+    const target: TargetInfo = {
+      magnitude: 8,
+      angularSizeArcmin: 10,
+      typeCategory: "galaxies",
+    };
+    const position: TargetPosition = { altitudeDeg: 50, azimuthDeg: 180 };
+    const fullMoon: MoonCondition = { illumination: 1.0, altitudeDeg: 60 };
+
+    const withMoon = calculateObservationScore(
+      target,
+      position,
+      fullMoon,
+      perfectWeather,
+      DWARF_II
+    );
+    const withoutMoon = calculateObservationScore(
+      target,
+      position,
+      noMoon,
+      perfectWeather,
+      DWARF_II
+    );
+
+    expect(withoutMoon.overall).toBeGreaterThan(withMoon.overall);
+  });
+
+  it("overall score is between 0 and 100", () => {
+    const targets: TargetInfo[] = [
+      { magnitude: -2, angularSizeArcmin: 0.5, typeCategory: "moon_planets" },
+      { magnitude: 4, angularSizeArcmin: 66, typeCategory: "nebulae" },
+      { magnitude: 12, angularSizeArcmin: 2, typeCategory: "galaxies" },
+      { magnitude: 20, angularSizeArcmin: 1, typeCategory: "galaxies" },
+      { magnitude: null, angularSizeArcmin: null, typeCategory: "nebulae" },
+    ];
+    const positions: TargetPosition[] = [
+      { altitudeDeg: -10, azimuthDeg: 0 },
+      { altitudeDeg: 30, azimuthDeg: 180 },
+      { altitudeDeg: 90, azimuthDeg: 0 },
+    ];
+    const moons: MoonCondition[] = [
+      { illumination: 0, altitudeDeg: -10 },
+      { illumination: 1, altitudeDeg: 60 },
+    ];
+    const weathers: WeatherCondition[] = [
+      { cloudCoverPercent: 0, humidityPercent: 30, windSpeedKmh: 0 },
+      { cloudCoverPercent: 100, humidityPercent: 100, windSpeedKmh: 50 },
+    ];
+
+    for (const target of targets) {
+      for (const pos of positions) {
+        for (const moon of moons) {
+          for (const weather of weathers) {
+            const result = calculateObservationScore(
+              target,
+              pos,
+              moon,
+              weather,
+              DWARF_II
+            );
+            expect(result.overall).toBeGreaterThanOrEqual(0);
+            expect(result.overall).toBeLessThanOrEqual(100);
+            expect(typeof result.recommendation).toBe("string");
+            expect(result.recommendation.length).toBeGreaterThan(0);
+          }
+        }
+      }
+    }
+  });
+});

--- a/src/__tests__/lib/ai/shooting_advisor.test.ts
+++ b/src/__tests__/lib/ai/shooting_advisor.test.ts
@@ -1,0 +1,401 @@
+import {
+  classifyTargetBrightness,
+  recommendExposure,
+  recommendGain,
+  recommendStackFrames,
+  recommendShootingParams,
+  type TargetBrightness,
+} from "@/lib/ai/shooting_advisor";
+
+import {
+  DWARF_II,
+  DWARF_3,
+} from "@/lib/ai/equipment_profiles";
+
+// ---- classifyTargetBrightness ----
+
+describe("classifyTargetBrightness", () => {
+  it('returns "bright" for magnitude <= 4', () => {
+    expect(classifyTargetBrightness(4)).toBe("bright");
+    expect(classifyTargetBrightness(0)).toBe("bright");
+    expect(classifyTargetBrightness(-2)).toBe("bright");
+  });
+
+  it('returns "moderate" for magnitude 4-8', () => {
+    expect(classifyTargetBrightness(4.1)).toBe("moderate");
+    expect(classifyTargetBrightness(6)).toBe("moderate");
+    expect(classifyTargetBrightness(8)).toBe("moderate");
+  });
+
+  it('returns "faint" for magnitude 8-12', () => {
+    expect(classifyTargetBrightness(8.1)).toBe("faint");
+    expect(classifyTargetBrightness(10)).toBe("faint");
+    expect(classifyTargetBrightness(12)).toBe("faint");
+  });
+
+  it('returns "very_faint" for magnitude > 12', () => {
+    expect(classifyTargetBrightness(12.1)).toBe("very_faint");
+    expect(classifyTargetBrightness(15)).toBe("very_faint");
+    expect(classifyTargetBrightness(20)).toBe("very_faint");
+  });
+
+  it('returns "very_faint" for null magnitude', () => {
+    expect(classifyTargetBrightness(null)).toBe("very_faint");
+  });
+
+  it("handles exact boundary values correctly", () => {
+    // Exactly at boundary: 4 is bright, 8 is moderate, 12 is faint
+    expect(classifyTargetBrightness(4)).toBe("bright");
+    expect(classifyTargetBrightness(8)).toBe("moderate");
+    expect(classifyTargetBrightness(12)).toBe("faint");
+  });
+});
+
+// ---- recommendExposure ----
+
+describe("recommendExposure", () => {
+  it("returns base exposure for normal conditions (Bortle 4-6, low moon)", () => {
+    // Bortle 5 = no sky multiplier, low moon = no moon multiplier
+    expect(recommendExposure("bright", 5, 0.3, 15)).toBe(1);
+    expect(recommendExposure("moderate", 5, 0.3, 30)).toBe(5);
+    expect(recommendExposure("faint", 5, 0.3, 30)).toBe(10);
+    expect(recommendExposure("very_faint", 5, 0.3, 30)).toBe(15);
+  });
+
+  it("increases exposure for dark sky (Bortle 1-3)", () => {
+    const darkSky = recommendExposure("moderate", 2, 0.3, 30);
+    const normalSky = recommendExposure("moderate", 5, 0.3, 30);
+    expect(darkSky).toBeGreaterThan(normalSky);
+  });
+
+  it("multiplies by 1.5 for Bortle 1-3", () => {
+    // moderate base=5, dark sky=5*1.5=7.5 → rounded to 8
+    const result = recommendExposure("moderate", 2, 0.0, 30);
+    expect(result).toBe(8);
+  });
+
+  it("decreases exposure for light-polluted sky (Bortle 7-9)", () => {
+    const pollutedSky = recommendExposure("moderate", 8, 0.3, 30);
+    const normalSky = recommendExposure("moderate", 5, 0.3, 30);
+    expect(pollutedSky).toBeLessThan(normalSky);
+  });
+
+  it("multiplies by 0.5 for Bortle 7-9", () => {
+    // moderate base=5, polluted=5*0.5=2.5 → rounded to 3
+    const result = recommendExposure("moderate", 8, 0.0, 30);
+    expect(result).toBe(3);
+  });
+
+  it("decreases exposure for high moon illumination (> 0.7)", () => {
+    const brightMoon = recommendExposure("moderate", 5, 0.9, 30);
+    const darkMoon = recommendExposure("moderate", 5, 0.1, 30);
+    expect(brightMoon).toBeLessThan(darkMoon);
+  });
+
+  it("multiplies by 0.7 when moon illumination > 0.7", () => {
+    // moderate base=5, moon=5*0.7=3.5 → rounded to 4
+    const result = recommendExposure("moderate", 5, 0.8, 30);
+    expect(result).toBe(4);
+  });
+
+  it("applies both dark sky and moon adjustments", () => {
+    // faint base=10, dark sky=10*1.5=15, high moon=15*0.7=10.5 → 11
+    const result = recommendExposure("faint", 2, 0.8, 30);
+    expect(result).toBe(11);
+  });
+
+  it("applies both light pollution and moon adjustments", () => {
+    // moderate base=5, polluted=5*0.5=2.5, moon=2.5*0.7=1.75 → 2
+    const result = recommendExposure("moderate", 8, 0.9, 30);
+    expect(result).toBe(2);
+  });
+
+  it("clamps to maxExposureSec", () => {
+    // very_faint base=15, dark sky=15*1.5=22.5 → clamped to 15
+    const result = recommendExposure("very_faint", 2, 0.0, 15);
+    expect(result).toBe(15);
+  });
+
+  it("clamps to minimum of 0.1", () => {
+    // bright base=1, polluted=1*0.5=0.5, moon=0.5*0.7=0.35 → 0.4
+    // Still above 0.1 but let's verify the floor
+    const result = recommendExposure("bright", 8, 0.9, 30);
+    expect(result).toBeGreaterThanOrEqual(0.1);
+  });
+
+  it("returns a value from roundExposure", () => {
+    // All results should be nicely rounded
+    const result = recommendExposure("moderate", 5, 0.5, 30);
+    expect(result).toBe(5);
+  });
+
+  it("does not exceed maxExposureSec for any brightness", () => {
+    const brightnesses: TargetBrightness[] = [
+      "bright",
+      "moderate",
+      "faint",
+      "very_faint",
+    ];
+    for (const b of brightnesses) {
+      const result = recommendExposure(b, 1, 0.0, 5);
+      expect(result).toBeLessThanOrEqual(5);
+    }
+  });
+});
+
+// ---- recommendGain ----
+
+describe("recommendGain", () => {
+  it("returns low gain for bright targets", () => {
+    const gain = recommendGain("bright", DWARF_II);
+    // minGain + range * 0.1 = 0 + 240*0.1 = 24 → rounded to 20
+    expect(gain).toBe(20);
+  });
+
+  it("returns default gain for moderate targets", () => {
+    const gain = recommendGain("moderate", DWARF_II);
+    expect(gain).toBe(DWARF_II.defaultGain);
+  });
+
+  it("returns elevated gain for faint targets", () => {
+    const gain = recommendGain("faint", DWARF_II);
+    // defaultGain + range * 0.2 = 80 + 240*0.2 = 128 → rounded to 130
+    expect(gain).toBe(130);
+  });
+
+  it("returns high gain for very faint targets", () => {
+    const gain = recommendGain("very_faint", DWARF_II);
+    // defaultGain + range * 0.35 = 80 + 240*0.35 = 164 → rounded to 160
+    expect(gain).toBe(160);
+  });
+
+  it("returns different gains for DWARF 3 due to different defaultGain", () => {
+    const gainD2 = recommendGain("moderate", DWARF_II);
+    const gainD3 = recommendGain("moderate", DWARF_3);
+    expect(gainD2).toBe(80);
+    expect(gainD3).toBe(60);
+  });
+
+  it("rounds to nearest 10", () => {
+    const brightnesses: TargetBrightness[] = [
+      "bright",
+      "moderate",
+      "faint",
+      "very_faint",
+    ];
+    for (const b of brightnesses) {
+      const gain = recommendGain(b, DWARF_II);
+      expect(gain % 10).toBe(0);
+    }
+  });
+
+  it("never exceeds maxGain", () => {
+    const gain = recommendGain("very_faint", DWARF_II);
+    expect(gain).toBeLessThanOrEqual(DWARF_II.maxGain);
+  });
+
+  it("never goes below minGain", () => {
+    const gain = recommendGain("bright", DWARF_II);
+    expect(gain).toBeGreaterThanOrEqual(DWARF_II.minGain);
+  });
+
+  it("clamps to maxGain for equipment with narrow gain range", () => {
+    const narrowEquipment = {
+      ...DWARF_II,
+      minGain: 0,
+      maxGain: 50,
+      defaultGain: 30,
+    };
+    // very_faint: 30 + 50*0.35 = 47.5 → rounded to 50 → clamped to 50
+    const gain = recommendGain("very_faint", narrowEquipment);
+    expect(gain).toBeLessThanOrEqual(50);
+  });
+});
+
+// ---- recommendStackFrames ----
+
+describe("recommendStackFrames", () => {
+  it("returns frames for bright target at high altitude", () => {
+    // bright: 15 min integration, 1s exposure = 900 frames
+    const frames = recommendStackFrames(1, "bright", 60);
+    expect(frames).toBe(900);
+  });
+
+  it("returns frames for moderate target", () => {
+    // moderate: 30 min = 1800s, 5s exposure = 360 frames
+    const frames = recommendStackFrames(5, "moderate", 60);
+    expect(frames).toBe(360);
+  });
+
+  it("returns frames for faint target", () => {
+    // faint: 60 min = 3600s, 10s exposure = 360 frames
+    const frames = recommendStackFrames(10, "faint", 60);
+    expect(frames).toBe(360);
+  });
+
+  it("returns frames for very faint target", () => {
+    // very_faint: 90 min = 5400s, 15s exposure = 360 frames
+    const frames = recommendStackFrames(15, "very_faint", 60);
+    expect(frames).toBe(360);
+  });
+
+  it("increases frames by 50% for low altitude (< 30 deg)", () => {
+    const highAlt = recommendStackFrames(5, "moderate", 60);
+    const lowAlt = recommendStackFrames(5, "moderate", 20);
+    expect(lowAlt).toBe(Math.round(highAlt * 1.5));
+  });
+
+  it("altitude exactly at 30 deg does not trigger increase", () => {
+    const at30 = recommendStackFrames(5, "moderate", 30);
+    const at60 = recommendStackFrames(5, "moderate", 60);
+    expect(at30).toBe(at60);
+  });
+
+  it("enforces minimum of 10 frames", () => {
+    // bright: 15 min = 900s, very long exposure = few frames
+    // With 15s max exposure: 900/15 = 60, still above 10
+    // Use a very long exposure to test the floor
+    const frames = recommendStackFrames(15, "bright", 60);
+    expect(frames).toBeGreaterThanOrEqual(10);
+  });
+
+  it("enforces maximum of 2000 frames", () => {
+    // very_faint at low alt: 90*1.5 = 135 min = 8100s, 0.1s exposure = 81000 → clamped to 2000
+    const frames = recommendStackFrames(0.1, "very_faint", 10);
+    expect(frames).toBeLessThanOrEqual(2000);
+  });
+});
+
+// ---- recommendShootingParams (integration tests) ----
+
+describe("recommendShootingParams", () => {
+  it("returns correct recommendation for M42 (bright nebula)", () => {
+    const result = recommendShootingParams(
+      { magnitude: 4, typeCategory: "nebulae" },
+      { bortleClass: 5, moonIllumination: 0.2, altitudeDeg: 50 },
+      DWARF_II
+    );
+
+    expect(result.brightness).toBe("bright");
+    expect(result.exposureSec).toBe(1);
+    expect(result.gain).toBe(20);
+    expect(result.stackFrames).toBe(900);
+    expect(result.totalIntegrationMin).toBe(15);
+    expect(result.notes).toContain("Bright target");
+    expect(result.notes).toContain("Nebula target");
+  });
+
+  it("returns correct recommendation for a faint galaxy", () => {
+    const result = recommendShootingParams(
+      { magnitude: 11, typeCategory: "galaxies" },
+      { bortleClass: 4, moonIllumination: 0.1, altitudeDeg: 55 },
+      DWARF_3
+    );
+
+    expect(result.brightness).toBe("faint");
+    expect(result.exposureSec).toBe(10);
+    expect(result.gain).toBe(110);
+    expect(result.stackFrames).toBe(360);
+    expect(result.notes).toContain("Faint target");
+    expect(result.notes).toContain("Galaxy target");
+  });
+
+  it("returns correct recommendation for a planet", () => {
+    const result = recommendShootingParams(
+      { magnitude: -2, typeCategory: "moon_planets" },
+      { bortleClass: 6, moonIllumination: 0.5, altitudeDeg: 40 },
+      DWARF_II
+    );
+
+    expect(result.brightness).toBe("bright");
+    expect(result.exposureSec).toBeLessThanOrEqual(1);
+    expect(result.notes).toContain("Planetary target");
+  });
+
+  it("adjusts for light-polluted sky with bright moon", () => {
+    const result = recommendShootingParams(
+      { magnitude: 6, typeCategory: "nebulae" },
+      { bortleClass: 8, moonIllumination: 0.9, altitudeDeg: 45 },
+      DWARF_II
+    );
+
+    // Moderate base=5, polluted=5*0.5=2.5, moon=2.5*0.7=1.75 → 2
+    expect(result.exposureSec).toBe(2);
+    expect(result.notes).toContain("Light-polluted");
+    expect(result.notes).toContain("Bright moon");
+  });
+
+  it("adjusts for low altitude target", () => {
+    const highAlt = recommendShootingParams(
+      { magnitude: 8, typeCategory: "clusters" },
+      { bortleClass: 5, moonIllumination: 0.2, altitudeDeg: 60 },
+      DWARF_II
+    );
+
+    const lowAlt = recommendShootingParams(
+      { magnitude: 8, typeCategory: "clusters" },
+      { bortleClass: 5, moonIllumination: 0.2, altitudeDeg: 20 },
+      DWARF_II
+    );
+
+    // Same exposure and gain, but more frames for low altitude
+    expect(lowAlt.stackFrames).toBeGreaterThan(highAlt.stackFrames);
+    expect(lowAlt.notes).toContain("Low altitude");
+  });
+
+  it("handles null magnitude as very faint", () => {
+    const result = recommendShootingParams(
+      { magnitude: null, typeCategory: "galaxies" },
+      { bortleClass: 5, moonIllumination: 0.2, altitudeDeg: 50 },
+      DWARF_3
+    );
+
+    expect(result.brightness).toBe("very_faint");
+    expect(result.exposureSec).toBe(15);
+  });
+
+  it("calculates totalIntegrationMin correctly", () => {
+    const result = recommendShootingParams(
+      { magnitude: 6, typeCategory: "nebulae" },
+      { bortleClass: 5, moonIllumination: 0.2, altitudeDeg: 60 },
+      DWARF_II
+    );
+
+    const expected =
+      Math.round(((result.exposureSec * result.stackFrames) / 60) * 10) / 10;
+    expect(result.totalIntegrationMin).toBe(expected);
+  });
+
+  it("respects equipment maxExposureSec for dark sky very faint target", () => {
+    // DWARF II maxExposureSec = 15, very_faint base=15, dark sky=15*1.5=22.5 → clamped to 15
+    const result = recommendShootingParams(
+      { magnitude: 14, typeCategory: "galaxies" },
+      { bortleClass: 2, moonIllumination: 0.0, altitudeDeg: 60 },
+      DWARF_II
+    );
+
+    expect(result.exposureSec).toBeLessThanOrEqual(DWARF_II.maxExposureSec);
+  });
+
+  it("gives different recommendations for DWARF II vs DWARF 3", () => {
+    const target = { magnitude: 9 as number | null, typeCategory: "galaxies" as const };
+    const conditions = {
+      bortleClass: 5,
+      moonIllumination: 0.2,
+      altitudeDeg: 50,
+    };
+
+    const d2 = recommendShootingParams(target, conditions, DWARF_II);
+    const d3 = recommendShootingParams(target, conditions, DWARF_3);
+
+    // Both should have same brightness classification
+    expect(d2.brightness).toBe(d3.brightness);
+
+    // Different gain due to different defaultGain
+    expect(d2.gain).not.toBe(d3.gain);
+
+    // DWARF 3 allows longer exposure (maxExposureSec=30 vs 15)
+    // For faint brightness base=10, no modifiers, both equipment can handle it
+    expect(d2.exposureSec).toBe(d3.exposureSec);
+  });
+});

--- a/src/lib/ai/equipment_profiles.ts
+++ b/src/lib/ai/equipment_profiles.ts
@@ -21,32 +21,38 @@ export interface EquipmentProfile {
   maxExposureSec: number;
 }
 
+// IMX415: 3840x2160 @ 1.45µm → active area 5.568x3.132mm
+// FOV = 2*atan(sensor/(2*focal))*180/π → 3.189° x 1.794°
+// ~2.99 arcsec/pixel, preview 1280x720
 export const DWARF_II: EquipmentProfile = {
   name: "DWARF II",
   apertureMm: 24,
   focalLengthMm: 100,
-  sensorWidthMm: 6.4,
-  sensorHeightMm: 3.6,
-  pixelSizeUm: 2.0,
+  sensorWidthMm: 5.568,
+  sensorHeightMm: 3.132,
+  pixelSizeUm: 1.45,
   resolutionWidth: 1280,
   resolutionHeight: 720,
-  fovWidthDeg: 3.188,
+  fovWidthDeg: 3.189,
   fovHeightDeg: 1.794,
   limitingMagnitude: 14,
   maxExposureSec: 15,
 };
 
+// IMX678: 3840x2160 @ 2.0µm → active area 7.680x4.320mm
+// FOV = 2*atan(sensor/(2*focal))*180/π → 2.933° x 1.650°
+// ~2.75 arcsec/pixel, confirmed by Wido's AstroForum review
 export const DWARF_3: EquipmentProfile = {
   name: "DWARF 3",
   apertureMm: 35,
   focalLengthMm: 150,
-  sensorWidthMm: 7.9,
-  sensorHeightMm: 4.4,
+  sensorWidthMm: 7.680,
+  sensorHeightMm: 4.320,
   pixelSizeUm: 2.0,
   resolutionWidth: 1920,
   resolutionHeight: 1080,
-  fovWidthDeg: 3.188,
-  fovHeightDeg: 1.794,
+  fovWidthDeg: 2.933,
+  fovHeightDeg: 1.650,
   limitingMagnitude: 16,
   maxExposureSec: 30,
 };

--- a/src/lib/ai/equipment_profiles.ts
+++ b/src/lib/ai/equipment_profiles.ts
@@ -1,6 +1,6 @@
 /**
  * Equipment profiles for DWARF telescope models.
- * Used by observation_scorer and future shooting_advisor.
+ * Used by observation_scorer and shooting_advisor.
  */
 
 export interface EquipmentProfile {

--- a/src/lib/ai/equipment_profiles.ts
+++ b/src/lib/ai/equipment_profiles.ts
@@ -1,0 +1,60 @@
+/**
+ * Equipment profiles for DWARF telescope models.
+ * Used by observation_scorer and future shooting_advisor.
+ */
+
+export interface EquipmentProfile {
+  name: string;
+  apertureMm: number;
+  focalLengthMm: number;
+  sensorWidthMm: number;
+  sensorHeightMm: number;
+  pixelSizeUm: number;
+  resolutionWidth: number;
+  resolutionHeight: number;
+  // Field of view in degrees
+  fovWidthDeg: number;
+  fovHeightDeg: number;
+  // Limiting magnitude for point sources (approximate)
+  limitingMagnitude: number;
+  // Maximum recommended exposure in seconds
+  maxExposureSec: number;
+}
+
+export const DWARF_II: EquipmentProfile = {
+  name: "DWARF II",
+  apertureMm: 24,
+  focalLengthMm: 100,
+  sensorWidthMm: 6.4,
+  sensorHeightMm: 3.6,
+  pixelSizeUm: 2.0,
+  resolutionWidth: 1280,
+  resolutionHeight: 720,
+  fovWidthDeg: 3.188,
+  fovHeightDeg: 1.794,
+  limitingMagnitude: 14,
+  maxExposureSec: 15,
+};
+
+export const DWARF_3: EquipmentProfile = {
+  name: "DWARF 3",
+  apertureMm: 35,
+  focalLengthMm: 150,
+  sensorWidthMm: 7.9,
+  sensorHeightMm: 4.4,
+  pixelSizeUm: 2.0,
+  resolutionWidth: 1920,
+  resolutionHeight: 1080,
+  fovWidthDeg: 3.188,
+  fovHeightDeg: 1.794,
+  limitingMagnitude: 16,
+  maxExposureSec: 30,
+};
+
+export function getProfileByName(name: string): EquipmentProfile | undefined {
+  const profiles: Record<string, EquipmentProfile> = {
+    "DWARF II": DWARF_II,
+    "DWARF 3": DWARF_3,
+  };
+  return profiles[name];
+}

--- a/src/lib/ai/equipment_profiles.ts
+++ b/src/lib/ai/equipment_profiles.ts
@@ -19,6 +19,10 @@ export interface EquipmentProfile {
   limitingMagnitude: number;
   // Maximum recommended exposure in seconds
   maxExposureSec: number;
+  // Gain range for the sensor
+  minGain: number;
+  maxGain: number;
+  defaultGain: number;
 }
 
 // IMX415: 3840x2160 @ 1.45µm → active area 5.568x3.132mm
@@ -37,6 +41,9 @@ export const DWARF_II: EquipmentProfile = {
   fovHeightDeg: 1.794,
   limitingMagnitude: 14,
   maxExposureSec: 15,
+  minGain: 0,
+  maxGain: 240,
+  defaultGain: 80,
 };
 
 // IMX678: 3840x2160 @ 2.0µm → active area 7.680x4.320mm
@@ -55,6 +62,9 @@ export const DWARF_3: EquipmentProfile = {
   fovHeightDeg: 1.650,
   limitingMagnitude: 16,
   maxExposureSec: 30,
+  minGain: 0,
+  maxGain: 240,
+  defaultGain: 60,
 };
 
 export function getProfileByName(name: string): EquipmentProfile | undefined {

--- a/src/lib/ai/observation_scorer.ts
+++ b/src/lib/ai/observation_scorer.ts
@@ -1,0 +1,247 @@
+/**
+ * Observation scorer: rates target × conditions → 0-100 score.
+ * Pure functions, no external API calls.
+ */
+
+import type { EquipmentProfile } from "./equipment_profiles";
+
+// ---- Input types ----
+
+export interface TargetInfo {
+  /** Visual magnitude (null if unknown) */
+  magnitude: number | null;
+  /** Angular size in arcminutes (null if point source) */
+  angularSizeArcmin: number | null;
+  /** DSO type category: "galaxies" | "nebulae" | "clusters" | "stars" | "moon_planets" */
+  typeCategory: string;
+}
+
+export interface TargetPosition {
+  /** Altitude above horizon in degrees */
+  altitudeDeg: number;
+  /** Azimuth in degrees */
+  azimuthDeg: number;
+}
+
+export interface MoonCondition {
+  /** Moon illumination fraction 0.0 - 1.0 */
+  illumination: number;
+  /** Moon altitude in degrees (negative = below horizon) */
+  altitudeDeg: number;
+}
+
+export interface WeatherCondition {
+  /** Cloud cover percentage 0-100 */
+  cloudCoverPercent: number;
+  /** Relative humidity percentage 0-100 */
+  humidityPercent: number;
+  /** Wind speed in km/h */
+  windSpeedKmh: number;
+}
+
+// ---- Output types ----
+
+export interface ObservationScore {
+  /** Overall score 0-100 */
+  overall: number;
+  factors: {
+    /** Target altitude score 0-100 */
+    altitude: number;
+    /** Moon impact score 0-100 (100 = no impact) */
+    moonImpact: number;
+    /** Weather conditions score 0-100 */
+    weather: number;
+    /** Target difficulty score 0-100 (100 = easy target) */
+    targetDifficulty: number;
+  };
+  /** Short recommendation text */
+  recommendation: string;
+}
+
+// ---- Scoring weights ----
+
+const WEIGHTS = {
+  altitude: 0.30,
+  moonImpact: 0.20,
+  weather: 0.30,
+  targetDifficulty: 0.20,
+};
+
+// ---- Scoring functions ----
+
+/**
+ * Score based on target altitude.
+ * Higher altitude = less atmospheric extinction = better.
+ */
+export function scoreAltitude(altitudeDeg: number): number {
+  if (altitudeDeg <= 0) return 0;
+  if (altitudeDeg >= 70) return 100;
+
+  // Optimal range: 40-70 degrees
+  if (altitudeDeg >= 40) return 85 + (altitudeDeg - 40) * (15 / 30);
+
+  // Usable range: 15-40 degrees
+  if (altitudeDeg >= 15) return 30 + (altitudeDeg - 15) * (55 / 25);
+
+  // Low altitude: 0-15 degrees — poor due to atmospheric extinction
+  return (altitudeDeg / 15) * 30;
+}
+
+/**
+ * Score the impact of moonlight on observations.
+ * Depends on moon illumination and altitude, plus target type.
+ */
+export function scoreMoonImpact(
+  moon: MoonCondition,
+  typeCategory: string
+): number {
+  // Moon below horizon = no impact
+  if (moon.altitudeDeg <= 0) return 100;
+
+  // Clusters/stars are less affected by moonlight than faint nebulae/galaxies
+  const sensitivity =
+    typeCategory === "clusters" || typeCategory === "stars" ? 0.5 : 1.0;
+
+  // Base moon impact: illumination * how high the moon is
+  const moonAltFactor = Math.min(moon.altitudeDeg / 45, 1.0);
+  const impact = moon.illumination * moonAltFactor * sensitivity;
+
+  return Math.round(Math.max(0, (1 - impact) * 100));
+}
+
+/**
+ * Score weather conditions for astronomical observation.
+ */
+export function scoreWeather(weather: WeatherCondition): number {
+  // Cloud cover is the primary factor
+  const cloudScore = Math.max(0, 100 - weather.cloudCoverPercent);
+
+  // High humidity causes dew and poor seeing
+  let humidityPenalty = 0;
+  if (weather.humidityPercent > 80) {
+    humidityPenalty = (weather.humidityPercent - 80) * 1.5;
+  }
+
+  // Wind causes vibration and poor tracking
+  let windPenalty = 0;
+  if (weather.windSpeedKmh > 20) {
+    windPenalty = Math.min(30, (weather.windSpeedKmh - 20) * 1.0);
+  }
+
+  return Math.round(Math.max(0, Math.min(100, cloudScore - humidityPenalty - windPenalty)));
+}
+
+/**
+ * Score target difficulty based on magnitude, size, type, and equipment.
+ * Returns 100 for easy targets, 0 for impossible ones.
+ */
+export function scoreTargetDifficulty(
+  target: TargetInfo,
+  equipment: EquipmentProfile
+): number {
+  let score = 100;
+
+  // Magnitude check
+  if (target.magnitude !== null) {
+    if (target.magnitude > equipment.limitingMagnitude) {
+      // Too faint for this equipment
+      return 0;
+    }
+
+    // Bright objects are easier
+    if (target.magnitude <= 4) {
+      score = 100;
+    } else if (target.magnitude <= 8) {
+      score = 90 - (target.magnitude - 4) * 5;
+    } else if (target.magnitude <= 12) {
+      score = 70 - (target.magnitude - 8) * 10;
+    } else {
+      score = 30 - (target.magnitude - 12) * 7.5;
+    }
+  } else {
+    // Unknown magnitude — assume moderate difficulty
+    score = 50;
+  }
+
+  // Size considerations
+  if (target.angularSizeArcmin !== null) {
+    const fovMin = Math.min(equipment.fovWidthDeg, equipment.fovHeightDeg) * 60;
+
+    if (target.angularSizeArcmin > fovMin * 2) {
+      // Much larger than FOV — need mosaic, harder
+      score = Math.max(0, score - 20);
+    } else if (target.angularSizeArcmin > fovMin) {
+      // Larger than FOV — partially visible
+      score = Math.max(0, score - 10);
+    } else if (target.angularSizeArcmin < 1) {
+      // Very small — harder to resolve
+      score = Math.max(0, score - 15);
+    }
+  }
+
+  // Planets/Moon are bright but require different technique
+  if (target.typeCategory === "moon_planets") {
+    score = Math.min(score, 60);
+  }
+
+  return Math.round(Math.max(0, Math.min(100, score)));
+}
+
+/**
+ * Generate a recommendation string based on scores.
+ */
+export function generateRecommendation(
+  overall: number,
+  factors: ObservationScore["factors"],
+  altitudeDeg: number
+): string {
+  if (overall >= 80) return "Excellent conditions. Highly recommended.";
+  if (overall >= 60) {
+    if (factors.weather < 50) return "Good target, but weather may interfere.";
+    if (factors.moonImpact < 50) return "Good target, but moonlight will reduce contrast.";
+    if (factors.altitude < 50) return "Good target, wait for higher altitude.";
+    return "Good conditions for observation.";
+  }
+  if (overall >= 40) {
+    if (factors.targetDifficulty < 30) return "Challenging target for this equipment.";
+    if (altitudeDeg <= 0) return "Target is below the horizon.";
+    if (factors.weather < 30) return "Poor weather conditions. Consider postponing.";
+    return "Marginal conditions. Results may vary.";
+  }
+  if (altitudeDeg <= 0) return "Target is below the horizon.";
+  if (factors.targetDifficulty === 0) return "Target is too faint for this equipment.";
+  return "Poor conditions. Not recommended.";
+}
+
+/**
+ * Calculate the overall observation score.
+ */
+export function calculateObservationScore(
+  target: TargetInfo,
+  position: TargetPosition,
+  moon: MoonCondition,
+  weather: WeatherCondition,
+  equipment: EquipmentProfile
+): ObservationScore {
+  const factors = {
+    altitude: scoreAltitude(position.altitudeDeg),
+    moonImpact: scoreMoonImpact(moon, target.typeCategory),
+    weather: scoreWeather(weather),
+    targetDifficulty: scoreTargetDifficulty(target, equipment),
+  };
+
+  const overall = Math.round(
+    factors.altitude * WEIGHTS.altitude +
+    factors.moonImpact * WEIGHTS.moonImpact +
+    factors.weather * WEIGHTS.weather +
+    factors.targetDifficulty * WEIGHTS.targetDifficulty
+  );
+
+  const recommendation = generateRecommendation(
+    overall,
+    factors,
+    position.altitudeDeg
+  );
+
+  return { overall, factors, recommendation };
+}

--- a/src/lib/ai/observation_scorer.ts
+++ b/src/lib/ai/observation_scorer.ts
@@ -7,13 +7,27 @@ import type { EquipmentProfile } from "./equipment_profiles";
 
 // ---- Input types ----
 
+// Known categories from data/objectTypes.js
+export type DsoTypeCategory =
+  | "galaxies"
+  | "nebulae"
+  | "clusters"
+  | "stars"
+  | "moon_planets"
+  | "asteroids"
+  | "comet"
+  | "duplicate"
+  | "nonexistent"
+  | "other"
+  | "mosaic";
+
 export interface TargetInfo {
   /** Visual magnitude (null if unknown) */
   magnitude: number | null;
   /** Angular size in arcminutes (null if point source) */
   angularSizeArcmin: number | null;
-  /** DSO type category: "galaxies" | "nebulae" | "clusters" | "stars" | "moon_planets" */
-  typeCategory: string;
+  /** DSO type category */
+  typeCategory: DsoTypeCategory;
 }
 
 export interface TargetPosition {
@@ -93,7 +107,7 @@ export function scoreAltitude(altitudeDeg: number): number {
  */
 export function scoreMoonImpact(
   moon: MoonCondition,
-  typeCategory: string
+  typeCategory: DsoTypeCategory
 ): number {
   // Moon below horizon = no impact
   if (moon.altitudeDeg <= 0) return 100;

--- a/src/lib/ai/shooting_advisor.ts
+++ b/src/lib/ai/shooting_advisor.ts
@@ -1,0 +1,261 @@
+/**
+ * Shooting parameter advisor: recommends exposure, gain, and stack frames
+ * based on target brightness, sky conditions, and equipment capabilities.
+ * Pure functions, no external API calls.
+ */
+
+import type { EquipmentProfile } from "./equipment_profiles";
+import type { DsoTypeCategory } from "./observation_scorer";
+import { roundExposure } from "@/lib/math_utils";
+
+// ---- Types ----
+
+export type TargetBrightness = "bright" | "moderate" | "faint" | "very_faint";
+
+export interface ShootingRecommendation {
+  exposureSec: number;
+  gain: number;
+  stackFrames: number;
+  totalIntegrationMin: number;
+  brightness: TargetBrightness;
+  notes: string;
+}
+
+// ---- Base exposure lookup ----
+
+const BASE_EXPOSURE: Record<TargetBrightness, number> = {
+  bright: 1,
+  moderate: 5,
+  faint: 10,
+  very_faint: 15,
+};
+
+// ---- Target integration time in minutes ----
+
+const TARGET_INTEGRATION_MIN: Record<TargetBrightness, number> = {
+  bright: 15,
+  moderate: 30,
+  faint: 60,
+  very_faint: 90,
+};
+
+// ---- Functions ----
+
+/**
+ * Classify a target by brightness based on its visual magnitude.
+ * Brighter objects have lower magnitudes.
+ */
+export function classifyTargetBrightness(
+  magnitude: number | null
+): TargetBrightness {
+  if (magnitude === null) return "very_faint";
+  if (magnitude <= 4) return "bright";
+  if (magnitude <= 8) return "moderate";
+  if (magnitude <= 12) return "faint";
+  return "very_faint";
+}
+
+/**
+ * Recommend exposure time in seconds based on target brightness,
+ * sky conditions, and equipment limits.
+ *
+ * Dark skies allow longer exposures; light-polluted skies need shorter
+ * exposures to avoid washed-out backgrounds. Bright moon also requires
+ * shorter exposures.
+ */
+export function recommendExposure(
+  brightness: TargetBrightness,
+  bortleClass: number,
+  moonIllumination: number,
+  maxExposureSec: number
+): number {
+  let exposure = BASE_EXPOSURE[brightness];
+
+  // Dark sky (Bortle 1-3): can afford longer exposures
+  if (bortleClass <= 3) {
+    exposure *= 1.5;
+  }
+
+  // Light polluted sky (Bortle 7-9): shorter to avoid washed out frames
+  if (bortleClass >= 7) {
+    exposure *= 0.5;
+  }
+
+  // High moon illumination reduces effective exposure
+  if (moonIllumination > 0.7) {
+    exposure *= 0.7;
+  }
+
+  // Clamp to valid range
+  exposure = Math.max(0.1, Math.min(exposure, maxExposureSec));
+
+  return roundExposure(exposure);
+}
+
+/**
+ * Recommend gain setting based on target brightness and equipment profile.
+ * Brighter targets use lower gain; fainter targets need higher gain.
+ */
+export function recommendGain(
+  brightness: TargetBrightness,
+  equipment: EquipmentProfile
+): number {
+  const range = equipment.maxGain - equipment.minGain;
+
+  let gain: number;
+  switch (brightness) {
+    case "bright":
+      // Low gain for bright targets to avoid saturation
+      gain = equipment.minGain + range * 0.1;
+      break;
+    case "moderate":
+      gain = equipment.defaultGain;
+      break;
+    case "faint":
+      gain = equipment.defaultGain + range * 0.2;
+      break;
+    case "very_faint":
+      gain = equipment.defaultGain + range * 0.35;
+      break;
+  }
+
+  // Clamp and round to nearest 10
+  gain = Math.max(equipment.minGain, Math.min(gain, equipment.maxGain));
+  gain = Math.round(gain / 10) * 10;
+
+  return gain;
+}
+
+/**
+ * Recommend number of stacking frames based on exposure time,
+ * target brightness, and altitude above horizon.
+ *
+ * Low altitude targets need more frames to compensate for
+ * atmospheric extinction and turbulence.
+ */
+export function recommendStackFrames(
+  exposureSec: number,
+  brightness: TargetBrightness,
+  altitudeDeg: number
+): number {
+  let integrationMin = TARGET_INTEGRATION_MIN[brightness];
+
+  // Low altitude: increase integration by 50% to compensate for extinction
+  if (altitudeDeg < 30) {
+    integrationMin *= 1.5;
+  }
+
+  const totalSec = integrationMin * 60;
+  let frames = Math.round(totalSec / exposureSec);
+
+  // Clamp to reasonable range
+  frames = Math.max(10, Math.min(frames, 2000));
+
+  return frames;
+}
+
+/**
+ * Generate a brief human-readable note about the recommendation.
+ */
+function generateNotes(
+  brightness: TargetBrightness,
+  bortleClass: number,
+  moonIllumination: number,
+  altitudeDeg: number,
+  typeCategory: DsoTypeCategory
+): string {
+  const parts: string[] = [];
+
+  // Brightness context
+  switch (brightness) {
+    case "bright":
+      parts.push("Bright target — use short exposures to avoid saturation.");
+      break;
+    case "moderate":
+      parts.push("Moderate brightness — standard settings should work well.");
+      break;
+    case "faint":
+      parts.push("Faint target — longer exposures and more frames needed.");
+      break;
+    case "very_faint":
+      parts.push(
+        "Very faint target — maximize exposure and stacking for best results."
+      );
+      break;
+  }
+
+  // Sky condition warnings
+  if (bortleClass >= 7) {
+    parts.push("Light-polluted sky — consider narrowband filters if available.");
+  }
+  if (moonIllumination > 0.7) {
+    parts.push("Bright moon — shorter exposures to reduce sky glow.");
+  }
+  if (altitudeDeg < 30) {
+    parts.push(
+      "Low altitude — increased frames to compensate for atmospheric effects."
+    );
+  }
+
+  // Type-specific tips
+  if (typeCategory === "nebulae") {
+    parts.push("Nebula target — stacking improves faint structure detail.");
+  } else if (typeCategory === "galaxies") {
+    parts.push("Galaxy target — maximize integration time for spiral arms.");
+  } else if (typeCategory === "moon_planets") {
+    parts.push("Planetary target — consider video mode for lucky imaging.");
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Recommend complete shooting parameters for a DSO target.
+ * Orchestrates brightness classification, exposure, gain, and stacking.
+ */
+export function recommendShootingParams(
+  target: { magnitude: number | null; typeCategory: DsoTypeCategory },
+  conditions: {
+    bortleClass: number;
+    moonIllumination: number;
+    altitudeDeg: number;
+  },
+  equipment: EquipmentProfile
+): ShootingRecommendation {
+  const brightness = classifyTargetBrightness(target.magnitude);
+
+  const exposureSec = recommendExposure(
+    brightness,
+    conditions.bortleClass,
+    conditions.moonIllumination,
+    equipment.maxExposureSec
+  );
+
+  const gain = recommendGain(brightness, equipment);
+
+  const stackFrames = recommendStackFrames(
+    exposureSec,
+    brightness,
+    conditions.altitudeDeg
+  );
+
+  const totalIntegrationMin =
+    Math.round(((exposureSec * stackFrames) / 60) * 10) / 10;
+
+  const notes = generateNotes(
+    brightness,
+    conditions.bortleClass,
+    conditions.moonIllumination,
+    conditions.altitudeDeg,
+    target.typeCategory
+  );
+
+  return {
+    exposureSec,
+    gain,
+    stackFrames,
+    totalIntegrationMin,
+    brightness,
+    notes,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `shooting_advisor.ts` with rule-based exposure, gain, and stack frame recommendations
- Classify targets by brightness (bright/moderate/faint/very_faint) for parameter tuning
- Add gain range fields to equipment profiles (minGain, maxGain, defaultGain)
- 49 tests covering all recommendation functions

## Details
Pure-function module that recommends camera settings based on:
- Target magnitude/brightness classification
- Sky conditions (Bortle class, moon illumination)
- Target altitude above horizon
- Equipment capabilities (DWARF II vs DWARF 3)

## Test plan
- [x] All shooting advisor tests pass
- [x] Existing observation_scorer tests still pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)