### PR TITLE
feat(ai): add tonight's best DSO ranking

### DIFF
--- a/src/__tests__/lib/ai/observation_scorer.test.ts
+++ b/src/__tests__/lib/ai/observation_scorer.test.ts
@@ -299,7 +299,8 @@ describe("generateRecommendation", () => {
       { altitude: 90, moonImpact: 90, weather: 80, targetDifficulty: 80 },
       60
     );
-    expect(result).toContain("Excellent");
+    expect(result.text).toContain("Excellent");
+    expect(result.code).toBe("excellent");
   });
 
   it("mentions weather for good target with poor weather", () => {
@@ -308,7 +309,8 @@ describe("generateRecommendation", () => {
       { altitude: 90, moonImpact: 90, weather: 40, targetDifficulty: 80 },
       60
     );
-    expect(result).toContain("weather");
+    expect(result.text).toContain("weather");
+    expect(result.code).toBe("good_weather_issue");
   });
 
   it("mentions moonlight for good target with bright moon", () => {
@@ -317,7 +319,8 @@ describe("generateRecommendation", () => {
       { altitude: 90, moonImpact: 40, weather: 80, targetDifficulty: 80 },
       60
     );
-    expect(result).toContain("moonlight");
+    expect(result.text).toContain("moonlight");
+    expect(result.code).toBe("good_moon_issue");
   });
 
   it("mentions altitude when target is low", () => {
@@ -326,7 +329,8 @@ describe("generateRecommendation", () => {
       { altitude: 40, moonImpact: 80, weather: 80, targetDifficulty: 80 },
       20
     );
-    expect(result).toContain("altitude");
+    expect(result.text).toContain("altitude");
+    expect(result.code).toBe("good_low_alt");
   });
 
   it("mentions below horizon when altitude <= 0", () => {
@@ -335,7 +339,8 @@ describe("generateRecommendation", () => {
       { altitude: 0, moonImpact: 90, weather: 80, targetDifficulty: 80 },
       -5
     );
-    expect(result).toContain("below the horizon");
+    expect(result.text).toContain("below the horizon");
+    expect(result.code).toBe("below_horizon");
   });
 
   it("mentions too faint when targetDifficulty is 0", () => {
@@ -344,7 +349,8 @@ describe("generateRecommendation", () => {
       { altitude: 80, moonImpact: 90, weather: 80, targetDifficulty: 0 },
       60
     );
-    expect(result).toContain("too faint");
+    expect(result.text).toContain("too faint");
+    expect(result.code).toBe("too_faint");
   });
 });
 
@@ -381,7 +387,7 @@ describe("calculateObservationScore", () => {
     expect(result.recommendation).toContain("Excellent");
   });
 
-  it("returns 0 overall when target is below horizon", () => {
+  it("returns low overall score when target is below horizon", () => {
     const target: TargetInfo = {
       magnitude: 4,
       angularSizeArcmin: 30,

--- a/src/__tests__/lib/ai/observation_scorer.test.ts
+++ b/src/__tests__/lib/ai/observation_scorer.test.ts
@@ -352,6 +352,26 @@ describe("generateRecommendation", () => {
     expect(result.text).toContain("too faint");
     expect(result.code).toBe("too_faint");
   });
+
+  it("prioritizes below_horizon even when overall is high", () => {
+    // alt=0 but other factors give overall ~70 — should still say below horizon
+    const result = generateRecommendation(
+      70,
+      { altitude: 0, moonImpact: 100, weather: 100, targetDifficulty: 100 },
+      -5
+    );
+    expect(result.code).toBe("below_horizon");
+  });
+
+  it("prioritizes too_faint even when overall is high", () => {
+    // targetDifficulty=0 but other factors give overall ~80
+    const result = generateRecommendation(
+      80,
+      { altitude: 100, moonImpact: 100, weather: 100, targetDifficulty: 0 },
+      60
+    );
+    expect(result.code).toBe("too_faint");
+  });
 });
 
 // ---- calculateObservationScore (integration) ----

--- a/src/__tests__/lib/ai/observation_scorer.test.ts
+++ b/src/__tests__/lib/ai/observation_scorer.test.ts
@@ -407,7 +407,7 @@ describe("calculateObservationScore", () => {
     expect(result.recommendation).toContain("Excellent");
   });
 
-  it("returns low overall score when target is below horizon", () => {
+  it("returns 0 overall when target is below horizon", () => {
     const target: TargetInfo = {
       magnitude: 4,
       angularSizeArcmin: 30,
@@ -424,9 +424,9 @@ describe("calculateObservationScore", () => {
     );
 
     expect(result.factors.altitude).toBe(0);
-    // Altitude weight is 0.3, so even with other factors at 100,
-    // overall max = 0.7 * 100 = 70 (no altitude contribution)
-    expect(result.overall).toBeLessThanOrEqual(70);
+    // Below-horizon is a hard-stop: overall is clamped to 0
+    expect(result.overall).toBe(0);
+    expect(result.recommendationCode).toBe("below_horizon");
   });
 
   it("returns low score for poor weather", () => {
@@ -524,5 +524,27 @@ describe("calculateObservationScore", () => {
         }
       }
     }
+  });
+
+  it("clamps overall to 0 for too-faint target", () => {
+    // Magnitude 20 exceeds DWARF II limiting mag (14) → targetDifficulty=0
+    const target: TargetInfo = {
+      magnitude: 20,
+      angularSizeArcmin: 1,
+      typeCategory: "galaxies",
+    };
+    const position: TargetPosition = { altitudeDeg: 60, azimuthDeg: 180 };
+
+    const result = calculateObservationScore(
+      target,
+      position,
+      noMoon,
+      perfectWeather,
+      DWARF_II
+    );
+
+    expect(result.factors.targetDifficulty).toBe(0);
+    expect(result.overall).toBe(0);
+    expect(result.recommendationCode).toBe("too_faint");
   });
 });

--- a/src/__tests__/lib/ai/tonights_best.test.ts
+++ b/src/__tests__/lib/ai/tonights_best.test.ts
@@ -1,0 +1,331 @@
+import { rankTargetsForTonight } from "@/lib/ai/tonights_best";
+import { DWARF_II } from "@/lib/ai/equipment_profiles";
+import type { AstroObject } from "@/types";
+import type {
+  WeatherCondition,
+  MoonCondition,
+} from "@/lib/ai/observation_scorer";
+
+// Sample objects for testing
+const sampleObjects: AstroObject[] = [
+  {
+    designation: "M 42",
+    ra: "5h 35m 17.30s",
+    dec: "-5° 23' 28.0\"",
+    magnitude: 4,
+    type: "HII region",
+    typeCategory: "nebulae",
+    displayName: "M 42 - Orion Nebula",
+    alternateNames: "NGC 1976",
+    catalogue: "M",
+    objectNumber: 42,
+    size: "66'x60'",
+    constellation: "Ori",
+    notes: null,
+    favorite: false,
+  },
+  {
+    designation: "M 31",
+    ra: "0h 42m 44.30s",
+    dec: "+41° 16' 9.0\"",
+    magnitude: 3.4,
+    type: "galaxy",
+    typeCategory: "galaxies",
+    displayName: "M 31 - Andromeda Galaxy",
+    alternateNames: "NGC 224",
+    catalogue: "M",
+    objectNumber: 31,
+    size: "178'x63'",
+    constellation: "And",
+    notes: null,
+    favorite: false,
+  },
+  {
+    designation: "NGC 6543",
+    ra: "17h 58m 33.42s",
+    dec: "+66° 37' 59.5\"",
+    magnitude: 8.1,
+    type: "Planetary Nebula",
+    typeCategory: "nebulae",
+    displayName: "NGC 6543 - Cat's Eye Nebula",
+    alternateNames: null,
+    catalogue: "NGC",
+    objectNumber: 6543,
+    size: "0.3'",
+    constellation: "Dra",
+    notes: null,
+    favorite: false,
+  },
+  {
+    // Object without coordinates — should be skipped
+    designation: "TEST 1",
+    ra: null,
+    dec: null,
+    magnitude: null,
+    type: "unknown",
+    typeCategory: "other",
+    displayName: "TEST 1",
+    alternateNames: null,
+    catalogue: "TEST",
+    objectNumber: 1,
+    constellation: null,
+    notes: null,
+    favorite: false,
+  },
+];
+
+const clearWeather: WeatherCondition = {
+  cloudCoverPercent: 0,
+  humidityPercent: 40,
+  windSpeedKmh: 5,
+};
+
+const noMoon: MoonCondition = {
+  illumination: 0,
+  altitudeDeg: -10,
+};
+
+// Paris coordinates
+const lat = 48.85;
+const lon = 2.35;
+
+describe("rankTargetsForTonight", () => {
+  it("returns ranked targets sorted by score descending", () => {
+    const results = rankTargetsForTonight(
+      sampleObjects,
+      lat,
+      lon,
+      "Europe/Paris",
+      clearWeather,
+      noMoon,
+      DWARF_II
+    );
+
+    // At least some objects should be above horizon
+    // (exact count depends on time of day)
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i].score).toBeLessThanOrEqual(results[i - 1].score);
+    }
+  });
+
+  it("excludes objects without coordinates", () => {
+    const results = rankTargetsForTonight(
+      sampleObjects,
+      lat,
+      lon,
+      "Europe/Paris",
+      clearWeather,
+      noMoon,
+      DWARF_II
+    );
+
+    const testObj = results.find((r) => r.object.designation === "TEST 1");
+    expect(testObj).toBeUndefined();
+  });
+
+  it("excludes objects below minimum altitude", () => {
+    const results = rankTargetsForTonight(
+      sampleObjects,
+      lat,
+      lon,
+      "Europe/Paris",
+      clearWeather,
+      noMoon,
+      DWARF_II,
+      { minAltitudeDeg: 30 }
+    );
+
+    results.forEach((r) => {
+      expect(r.altitudeDeg).toBeGreaterThanOrEqual(30);
+    });
+  });
+
+  it("respects the limit option", () => {
+    const results = rankTargetsForTonight(
+      sampleObjects,
+      lat,
+      lon,
+      "Europe/Paris",
+      clearWeather,
+      noMoon,
+      DWARF_II,
+      { limit: 1 }
+    );
+
+    expect(results.length).toBeLessThanOrEqual(1);
+  });
+
+  it("respects the minScore option", () => {
+    const results = rankTargetsForTonight(
+      sampleObjects,
+      lat,
+      lon,
+      "Europe/Paris",
+      clearWeather,
+      noMoon,
+      DWARF_II,
+      { minScore: 50 }
+    );
+
+    results.forEach((r) => {
+      expect(r.score).toBeGreaterThanOrEqual(50);
+    });
+  });
+
+  it("returns RankedTarget shape with required fields", () => {
+    const results = rankTargetsForTonight(
+      sampleObjects,
+      lat,
+      lon,
+      "Europe/Paris",
+      clearWeather,
+      noMoon,
+      DWARF_II
+    );
+
+    results.forEach((r) => {
+      expect(r).toHaveProperty("object");
+      expect(r).toHaveProperty("score");
+      expect(r).toHaveProperty("altitudeDeg");
+      expect(r).toHaveProperty("azimuthDeg");
+      expect(r).toHaveProperty("recommendation");
+      expect(r.score).toBeGreaterThanOrEqual(0);
+      expect(r.score).toBeLessThanOrEqual(100);
+      expect(typeof r.recommendation).toBe("string");
+    });
+  });
+
+  it("returns empty array when no objects visible", () => {
+    const results = rankTargetsForTonight(
+      sampleObjects,
+      lat,
+      lon,
+      "Europe/Paris",
+      clearWeather,
+      noMoon,
+      DWARF_II,
+      { minAltitudeDeg: 89 } // Almost nothing at 89+ degrees
+    );
+
+    // Most objects won't be at 89+ degrees altitude
+    expect(results.length).toBeLessThanOrEqual(1);
+  });
+
+  it("returns empty array for empty input", () => {
+    const results = rankTargetsForTonight(
+      [],
+      lat,
+      lon,
+      "Europe/Paris",
+      clearWeather,
+      noMoon,
+      DWARF_II
+    );
+
+    expect(results).toEqual([]);
+  });
+
+  it("handles objects with string magnitude", () => {
+    const objsWithStringMag: AstroObject[] = [
+      {
+        ...sampleObjects[0],
+        magnitude: "4.00" as unknown as number,
+      },
+    ];
+
+    // Should not throw
+    const results = rankTargetsForTonight(
+      objsWithStringMag,
+      lat,
+      lon,
+      "Europe/Paris",
+      clearWeather,
+      noMoon,
+      DWARF_II
+    );
+
+    // If object is above horizon, it should have a valid score
+    results.forEach((r) => {
+      expect(r.score).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  it("handles objects with null magnitude", () => {
+    const objsNullMag: AstroObject[] = [
+      {
+        ...sampleObjects[0],
+        magnitude: null,
+      },
+    ];
+
+    const results = rankTargetsForTonight(
+      objsNullMag,
+      lat,
+      lon,
+      "Europe/Paris",
+      clearWeather,
+      noMoon,
+      DWARF_II
+    );
+
+    results.forEach((r) => {
+      expect(r.score).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  it("poor weather lowers scores", () => {
+    const poorWeather: WeatherCondition = {
+      cloudCoverPercent: 90,
+      humidityPercent: 95,
+      windSpeedKmh: 40,
+    };
+
+    const goodResults = rankTargetsForTonight(
+      sampleObjects,
+      lat,
+      lon,
+      "Europe/Paris",
+      clearWeather,
+      noMoon,
+      DWARF_II
+    );
+
+    const poorResults = rankTargetsForTonight(
+      sampleObjects,
+      lat,
+      lon,
+      "Europe/Paris",
+      poorWeather,
+      noMoon,
+      DWARF_II
+    );
+
+    // Same objects above horizon should score lower in poor weather
+    if (goodResults.length > 0 && poorResults.length > 0) {
+      const goodTop = goodResults[0];
+      const poorMatch = poorResults.find(
+        (r) => r.object.designation === goodTop.object.designation
+      );
+      if (poorMatch) {
+        expect(poorMatch.score).toBeLessThanOrEqual(goodTop.score);
+      }
+    }
+  });
+
+  it("altitude values are rounded to 1 decimal", () => {
+    const results = rankTargetsForTonight(
+      sampleObjects,
+      lat,
+      lon,
+      "Europe/Paris",
+      clearWeather,
+      noMoon,
+      DWARF_II
+    );
+
+    results.forEach((r) => {
+      const decimals = (r.altitudeDeg.toString().split(".")[1] || "").length;
+      expect(decimals).toBeLessThanOrEqual(1);
+    });
+  });
+});

--- a/src/components/GotoStellarium.tsx
+++ b/src/components/GotoStellarium.tsx
@@ -337,6 +337,7 @@ export default function ManualGoto(props: PropType) {
           setModule={setModule}
           setErrors={setErrors}
           setSuccess={setSuccess}
+          showScoreCard={true}
         />
       )}
       {objectNGC && <br />}

--- a/src/components/ai/ObservationScoreCard.tsx
+++ b/src/components/ai/ObservationScoreCard.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useTranslation } from "react-i18next";
-import { useContext } from "react";
+import { useContext, useMemo, useState, useEffect } from "react";
 
 import { ConnectionContext } from "@/stores/ConnectionContext";
 import { AstroObject } from "@/types";
@@ -58,8 +58,15 @@ export default function ObservationScoreCard({ object }: Props) {
   const connectionCtx = useContext(ConnectionContext);
   const { weather, moon, equipment, loading, error } = useObservationData();
 
-  // Compute current Alt/Az — no memoization so time-dependent values stay fresh
-  const position = (() => {
+  // Tick every 60s so Alt/Az refreshes without running on every render
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const timer = setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => clearInterval(timer);
+  }, []);
+
+  // Compute current Alt/Az (memoized, refreshes once per minute via tick)
+  const position = useMemo(() => {
     if (
       !object.ra ||
       !object.dec ||
@@ -82,10 +89,18 @@ export default function ObservationScoreCard({ object }: Props) {
     );
 
     return results ? { altitudeDeg: results.alt, azimuthDeg: results.az } : null;
-  })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    object.ra,
+    object.dec,
+    connectionCtx.latitude,
+    connectionCtx.longitude,
+    connectionCtx.timezone,
+    tick,
+  ]);
 
   // Calculate score when all data is available
-  const score = (() => {
+  const score = useMemo(() => {
     if (!weather || !moon || !equipment || !position) return null;
 
     const magnitude =
@@ -106,7 +121,7 @@ export default function ObservationScoreCard({ object }: Props) {
       weather,
       equipment
     );
-  })();
+  }, [weather, moon, equipment, position, object]);
 
   // Don't render if location not set
   if (connectionCtx.latitude == null || connectionCtx.longitude == null) return null;

--- a/src/components/ai/ObservationScoreCard.tsx
+++ b/src/components/ai/ObservationScoreCard.tsx
@@ -22,19 +22,21 @@ type Props = {
   object: AstroObject;
 };
 
-// Map recommendation text from scorer to i18n keys
-const RECOMMENDATION_KEY_MAP: Record<string, string> = {
-  "Excellent conditions. Highly recommended.": "cAiRecExcellent",
-  "Good target, but weather may interfere.": "cAiRecWeatherIssue",
-  "Good target, but moonlight will reduce contrast.": "cAiRecMoonIssue",
-  "Good target, wait for higher altitude.": "cAiRecLowAlt",
-  "Good conditions for observation.": "cAiRecGood",
-  "Challenging target for this equipment.": "cAiRecChallenging",
-  "Target is below the horizon.": "cAiRecBelowHorizon",
-  "Poor weather conditions. Consider postponing.": "cAiRecPoorWeather",
-  "Marginal conditions. Results may vary.": "cAiRecMarginal",
-  "Target is too faint for this equipment.": "cAiRecTooFaint",
-  "Poor conditions. Not recommended.": "cAiRecPoor",
+// Map recommendation codes from scorer to i18n keys
+import type { RecommendationCode } from "@/lib/ai/observation_scorer";
+
+const RECOMMENDATION_KEY_MAP: Record<RecommendationCode, string> = {
+  excellent: "cAiRecExcellent",
+  good_weather_issue: "cAiRecWeatherIssue",
+  good_moon_issue: "cAiRecMoonIssue",
+  good_low_alt: "cAiRecLowAlt",
+  good: "cAiRecGood",
+  challenging: "cAiRecChallenging",
+  below_horizon: "cAiRecBelowHorizon",
+  poor_weather: "cAiRecPoorWeather",
+  marginal: "cAiRecMarginal",
+  too_faint: "cAiRecTooFaint",
+  poor: "cAiRecPoor",
 };
 
 function getScoreColorClass(score: number): string {
@@ -61,14 +63,14 @@ export default function ObservationScoreCard({ object }: Props) {
     if (
       !object.ra ||
       !object.dec ||
-      !connectionCtx.latitude ||
-      !connectionCtx.longitude
+      connectionCtx.latitude == null ||
+      connectionCtx.longitude == null
     )
       return null;
 
     const raDecimal = convertHMSToDecimalDegrees(object.ra);
     const decDecimal = convertDMSToDecimalDegrees(object.dec);
-    if (!raDecimal || !decDecimal) return null;
+    if (isNaN(raDecimal) || isNaN(decDecimal)) return null;
 
     const results = computeRaDecToAltAz(
       connectionCtx.latitude,
@@ -113,7 +115,7 @@ export default function ObservationScoreCard({ object }: Props) {
   }, [weather, moon, equipment, position, object]);
 
   // Don't render if location not set
-  if (!connectionCtx.latitude || !connectionCtx.longitude) return null;
+  if (connectionCtx.latitude == null || connectionCtx.longitude == null) return null;
 
   if (loading) {
     return (
@@ -127,7 +129,7 @@ export default function ObservationScoreCard({ object }: Props) {
 
   if (error || !score) return null;
 
-  const recKey = RECOMMENDATION_KEY_MAP[score.recommendation];
+  const recKey = RECOMMENDATION_KEY_MAP[score.recommendationCode];
 
   const factors = [
     { label: "cAiScoreAltitude", value: score.factors.altitude },

--- a/src/components/ai/ObservationScoreCard.tsx
+++ b/src/components/ai/ObservationScoreCard.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useTranslation } from "react-i18next";
-import { useMemo, useContext } from "react";
+import { useContext } from "react";
 
 import { ConnectionContext } from "@/stores/ConnectionContext";
 import { AstroObject } from "@/types";
@@ -58,8 +58,8 @@ export default function ObservationScoreCard({ object }: Props) {
   const connectionCtx = useContext(ConnectionContext);
   const { weather, moon, equipment, loading, error } = useObservationData();
 
-  // Compute current Alt/Az for this object
-  const position = useMemo(() => {
+  // Compute current Alt/Az — no memoization so time-dependent values stay fresh
+  const position = (() => {
     if (
       !object.ra ||
       !object.dec ||
@@ -82,16 +82,10 @@ export default function ObservationScoreCard({ object }: Props) {
     );
 
     return results ? { altitudeDeg: results.alt, azimuthDeg: results.az } : null;
-  }, [
-    object.ra,
-    object.dec,
-    connectionCtx.latitude,
-    connectionCtx.longitude,
-    connectionCtx.timezone,
-  ]);
+  })();
 
   // Calculate score when all data is available
-  const score = useMemo(() => {
+  const score = (() => {
     if (!weather || !moon || !equipment || !position) return null;
 
     const magnitude =
@@ -112,7 +106,7 @@ export default function ObservationScoreCard({ object }: Props) {
       weather,
       equipment
     );
-  }, [weather, moon, equipment, position, object]);
+  })();
 
   // Don't render if location not set
   if (connectionCtx.latitude == null || connectionCtx.longitude == null) return null;

--- a/src/components/ai/ObservationScoreCard.tsx
+++ b/src/components/ai/ObservationScoreCard.tsx
@@ -1,0 +1,172 @@
+/**
+ * Observation Score Card — displays AI-scored observation conditions.
+ * Shows overall score (color-coded) + 4 factor bars + recommendation.
+ */
+
+import { useTranslation } from "react-i18next";
+import { useMemo, useContext } from "react";
+
+import { ConnectionContext } from "@/stores/ConnectionContext";
+import { AstroObject } from "@/types";
+import { useObservationData } from "@/hooks/useObservationData";
+import { calculateObservationScore } from "@/lib/ai/observation_scorer";
+import type { DsoTypeCategory } from "@/lib/ai/observation_scorer";
+import { computeRaDecToAltAz } from "@/lib/astro_utils";
+import {
+  convertHMSToDecimalDegrees,
+  convertDMSToDecimalDegrees,
+} from "@/lib/math_utils";
+import { toIsoStringInLocalTime } from "@/lib/date_utils";
+
+type Props = {
+  object: AstroObject;
+};
+
+// Map recommendation text from scorer to i18n keys
+const RECOMMENDATION_KEY_MAP: Record<string, string> = {
+  "Excellent conditions. Highly recommended.": "cAiRecExcellent",
+  "Good target, but weather may interfere.": "cAiRecWeatherIssue",
+  "Good target, but moonlight will reduce contrast.": "cAiRecMoonIssue",
+  "Good target, wait for higher altitude.": "cAiRecLowAlt",
+  "Good conditions for observation.": "cAiRecGood",
+  "Challenging target for this equipment.": "cAiRecChallenging",
+  "Target is below the horizon.": "cAiRecBelowHorizon",
+  "Poor weather conditions. Consider postponing.": "cAiRecPoorWeather",
+  "Marginal conditions. Results may vary.": "cAiRecMarginal",
+  "Target is too faint for this equipment.": "cAiRecTooFaint",
+  "Poor conditions. Not recommended.": "cAiRecPoor",
+};
+
+function getScoreColorClass(score: number): string {
+  if (score >= 70) return "ai-score-good";
+  if (score >= 40) return "ai-score-moderate";
+  return "ai-score-poor";
+}
+
+function parseAngularSize(sizeStr?: string): number | null {
+  if (!sizeStr) return null;
+  // Format is like "66'x60'" or "120'x100'"
+  const match = sizeStr.match(/^([\d.]+)/);
+  if (match) return parseFloat(match[1]);
+  return null;
+}
+
+export default function ObservationScoreCard({ object }: Props) {
+  const { t } = useTranslation();
+  const connectionCtx = useContext(ConnectionContext);
+  const { weather, moon, equipment, loading, error } = useObservationData();
+
+  // Compute current Alt/Az for this object
+  const position = useMemo(() => {
+    if (
+      !object.ra ||
+      !object.dec ||
+      !connectionCtx.latitude ||
+      !connectionCtx.longitude
+    )
+      return null;
+
+    const raDecimal = convertHMSToDecimalDegrees(object.ra);
+    const decDecimal = convertDMSToDecimalDegrees(object.dec);
+    if (!raDecimal || !decDecimal) return null;
+
+    const results = computeRaDecToAltAz(
+      connectionCtx.latitude,
+      connectionCtx.longitude,
+      raDecimal,
+      decDecimal,
+      toIsoStringInLocalTime(new Date()),
+      connectionCtx.timezone
+    );
+
+    return results ? { altitudeDeg: results.alt, azimuthDeg: results.az } : null;
+  }, [
+    object.ra,
+    object.dec,
+    connectionCtx.latitude,
+    connectionCtx.longitude,
+    connectionCtx.timezone,
+  ]);
+
+  // Calculate score when all data is available
+  const score = useMemo(() => {
+    if (!weather || !moon || !equipment || !position) return null;
+
+    const magnitude =
+      object.magnitude !== null && object.magnitude !== undefined
+        ? typeof object.magnitude === "string"
+          ? parseFloat(object.magnitude)
+          : object.magnitude
+        : null;
+
+    return calculateObservationScore(
+      {
+        magnitude: magnitude !== null && !isNaN(magnitude) ? magnitude : null,
+        angularSizeArcmin: parseAngularSize(object.size),
+        typeCategory: (object.typeCategory || "other") as DsoTypeCategory,
+      },
+      position,
+      moon,
+      weather,
+      equipment
+    );
+  }, [weather, moon, equipment, position, object]);
+
+  // Don't render if location not set
+  if (!connectionCtx.latitude || !connectionCtx.longitude) return null;
+
+  if (loading) {
+    return (
+      <div className="ai-score-card mt-2">
+        <small className="text-muted">
+          <i className="bi bi-hourglass-split"></i> {t("cAiScoreLoading")}
+        </small>
+      </div>
+    );
+  }
+
+  if (error || !score) return null;
+
+  const recKey = RECOMMENDATION_KEY_MAP[score.recommendation];
+
+  const factors = [
+    { label: "cAiScoreAltitude", value: score.factors.altitude },
+    { label: "cAiScoreWeather", value: score.factors.weather },
+    { label: "cAiScoreMoon", value: score.factors.moonImpact },
+    { label: "cAiScoreDifficulty", value: score.factors.targetDifficulty },
+  ];
+
+  return (
+    <div className="ai-score-card mt-2 mb-2 p-2 border rounded">
+      <div className="row align-items-center">
+        <div className="col-auto">
+          <div
+            className={`ai-score-badge ${getScoreColorClass(score.overall)}`}
+          >
+            {score.overall}
+          </div>
+        </div>
+        <div className="col">
+          <strong>{t("cAiScoreTitle")}</strong>
+          <div className="mt-1">
+            {factors.map((f) => (
+              <div key={f.label} className="d-flex align-items-center mb-1">
+                <small className="ai-score-label">{t(f.label)}</small>
+                <div className="progress ai-score-bar flex-grow-1">
+                  <div
+                    className={`progress-bar ${getScoreColorClass(f.value)}`}
+                    style={{ width: `${f.value}%` }}
+                  ></div>
+                </div>
+                <small className="ai-score-value">{f.value}</small>
+              </div>
+            ))}
+          </div>
+          <small className="text-muted">
+            {recKey ? t(recKey) : score.recommendation}
+          </small>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ai/TonightsBest.tsx
+++ b/src/components/ai/TonightsBest.tsx
@@ -41,8 +41,8 @@ export default function TonightsBest(props: Props) {
 
   const ranked: RankedTarget[] = useMemo(() => {
     if (
-      !connectionCtx.latitude ||
-      !connectionCtx.longitude ||
+      connectionCtx.latitude == null ||
+      connectionCtx.longitude == null ||
       !weather ||
       !moon ||
       !equipment
@@ -69,7 +69,7 @@ export default function TonightsBest(props: Props) {
     refreshKey,
   ]);
 
-  if (!connectionCtx.latitude || !connectionCtx.longitude) {
+  if (connectionCtx.latitude == null || connectionCtx.longitude == null) {
     return (
       <div className="p-3 text-center text-muted">
         <i className="bi bi-geo-alt"></i> {t("cAiTonightNoLocation")}

--- a/src/components/ai/TonightsBest.tsx
+++ b/src/components/ai/TonightsBest.tsx
@@ -127,6 +127,7 @@ export default function TonightsBest(props: Props) {
             setModule={props.setModule}
             setErrors={props.setErrors}
             setSuccess={props.setSuccess}
+            showScoreCard={false}
           />
         </div>
       ))}

--- a/src/components/ai/TonightsBest.tsx
+++ b/src/components/ai/TonightsBest.tsx
@@ -1,0 +1,141 @@
+/**
+ * Tonight's Best — ranked list of DSO targets for the current session.
+ * Integrated into the objects page as a new tab.
+ */
+
+import { useTranslation } from "react-i18next";
+import { useState, useContext, useMemo, useCallback } from "react";
+import type { Dispatch, SetStateAction } from "react";
+
+import { ConnectionContext } from "@/stores/ConnectionContext";
+import { AstroObject } from "@/types";
+import { useObservationData } from "@/hooks/useObservationData";
+import { rankTargetsForTonight } from "@/lib/ai/tonights_best";
+import type { RankedTarget } from "@/lib/ai/tonights_best";
+import { processObjectListOpenNGC } from "@/lib/observation_lists_utils";
+import DSOObject from "@/components/astroObjects/DSOObject";
+
+import dsoCatalog from "../../../data/catalogs/dso_catalog.json";
+
+const dsoObjects: AstroObject[] = processObjectListOpenNGC(dsoCatalog);
+
+type Props = {
+  objectFavoriteNames: string[];
+  setObjectFavoriteNames: Dispatch<SetStateAction<string[]>>;
+  objectPersonalList: AstroObject[];
+  setObjectPersonalList: Dispatch<SetStateAction<AstroObject[]>>;
+  setModule: Dispatch<SetStateAction<string | undefined>>;
+  setErrors: Dispatch<SetStateAction<string | undefined>>;
+  setSuccess: Dispatch<SetStateAction<string | undefined>>;
+};
+
+export default function TonightsBest(props: Props) {
+  const { t } = useTranslation();
+  const connectionCtx = useContext(ConnectionContext);
+  const { weather, moon, equipment, loading, error } = useObservationData();
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const handleRefresh = useCallback(() => {
+    setRefreshKey((k) => k + 1);
+  }, []);
+
+  const ranked: RankedTarget[] = useMemo(() => {
+    if (
+      !connectionCtx.latitude ||
+      !connectionCtx.longitude ||
+      !weather ||
+      !moon ||
+      !equipment
+    )
+      return [];
+
+    return rankTargetsForTonight(
+      dsoObjects,
+      connectionCtx.latitude,
+      connectionCtx.longitude,
+      connectionCtx.timezone,
+      weather,
+      moon,
+      equipment,
+      { limit: 30, minAltitudeDeg: 10 }
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    connectionCtx.latitude,
+    connectionCtx.longitude,
+    weather,
+    moon,
+    equipment,
+    refreshKey,
+  ]);
+
+  if (!connectionCtx.latitude || !connectionCtx.longitude) {
+    return (
+      <div className="p-3 text-center text-muted">
+        <i className="bi bi-geo-alt"></i> {t("cAiTonightNoLocation")}
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="p-3 text-center text-muted">
+        <i className="bi bi-hourglass-split"></i> {t("cAiScoreLoading")}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-3 text-center text-danger">
+        <i className="bi bi-exclamation-triangle"></i> {error}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="d-flex justify-content-between align-items-center mb-2">
+        <h5 className="mb-0">
+          {t("cAiTonightTitle")} ({ranked.length})
+        </h5>
+        <button className="btn btn-sm btn-more02" onClick={handleRefresh}>
+          <i className="fa fa-refresh"></i> {t("cAiTonightRefresh")}
+        </button>
+      </div>
+
+      {ranked.length === 0 && (
+        <div className="p-3 text-center text-muted">
+          {t("cAiTonightEmpty")}
+        </div>
+      )}
+
+      {ranked.map((item, index) => (
+        <div key={item.object.designation} className="position-relative">
+          <div className="position-absolute top-0 start-0 p-2" style={{ zIndex: 1 }}>
+            <span className={`badge ${getScoreBadgeClass(item.score)} fs-6`}>
+              #{index + 1} · {item.score}
+            </span>
+          </div>
+          <DSOObject
+            object={item.object}
+            objectFavoriteNames={props.objectFavoriteNames}
+            setObjectFavoriteNames={props.setObjectFavoriteNames}
+            objectPersonalList={props.objectPersonalList}
+            setObjectPersonalList={props.setObjectPersonalList}
+            isInObjectPersonalList={false}
+            setModule={props.setModule}
+            setErrors={props.setErrors}
+            setSuccess={props.setSuccess}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function getScoreBadgeClass(score: number): string {
+  if (score >= 70) return "bg-success";
+  if (score >= 40) return "bg-warning text-dark";
+  return "bg-danger";
+}

--- a/src/components/astroObjects/DSOObject.tsx
+++ b/src/components/astroObjects/DSOObject.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/db/db_utils";
 import RemoveFromPersonalLibrary from "@/components/RemoveFromPersonalLibModal";
 import GotoModal from "./GotoModal";
+import ObservationScoreCard from "@/components/ai/ObservationScoreCard";
 
 type AstronomyObjectPropType = {
   object: AstroObject;
@@ -382,6 +383,7 @@ export default function DSOObject(props: AstronomyObjectPropType) {
               />
             </div>
           </div>
+          <ObservationScoreCard object={object} />
           <RemoveFromPersonalLibrary
             showModal={showRemoveModal}
             setShowModal={setShowRemoveModal}

--- a/src/components/astroObjects/DSOObject.tsx
+++ b/src/components/astroObjects/DSOObject.tsx
@@ -35,6 +35,7 @@ type AstronomyObjectPropType = {
   setModule: Dispatch<SetStateAction<string | undefined>>;
   setErrors: Dispatch<SetStateAction<string | undefined>>;
   setSuccess: Dispatch<SetStateAction<string | undefined>>;
+  showScoreCard?: boolean;
 };
 type Message = {
   [k: string]: string;
@@ -383,7 +384,7 @@ export default function DSOObject(props: AstronomyObjectPropType) {
               />
             </div>
           </div>
-          <ObservationScoreCard object={object} />
+          {props.showScoreCard !== false && <ObservationScoreCard object={object} />}
           <RemoveFromPersonalLibrary
             showModal={showRemoveModal}
             setShowModal={setShowRemoveModal}

--- a/src/components/astroObjects/DSOObject.tsx
+++ b/src/components/astroObjects/DSOObject.tsx
@@ -384,7 +384,7 @@ export default function DSOObject(props: AstronomyObjectPropType) {
               />
             </div>
           </div>
-          {props.showScoreCard !== false && <ObservationScoreCard object={object} />}
+          {props.showScoreCard === true && <ObservationScoreCard object={object} />}
           <RemoveFromPersonalLibrary
             showModal={showRemoveModal}
             setShowModal={setShowRemoveModal}

--- a/src/components/astroObjects/DSOObject.tsx
+++ b/src/components/astroObjects/DSOObject.tsx
@@ -35,6 +35,7 @@ type AstronomyObjectPropType = {
   setModule: Dispatch<SetStateAction<string | undefined>>;
   setErrors: Dispatch<SetStateAction<string | undefined>>;
   setSuccess: Dispatch<SetStateAction<string | undefined>>;
+  showScoreCard?: boolean;
 };
 type Message = {
   [k: string]: string;
@@ -383,7 +384,7 @@ export default function DSOObject(props: AstronomyObjectPropType) {
               />
             </div>
           </div>
-          <ObservationScoreCard object={object} />
+          {props.showScoreCard === true && <ObservationScoreCard object={object} />}
           <RemoveFromPersonalLibrary
             showModal={showRemoveModal}
             setShowModal={setShowRemoveModal}

--- a/src/lib/ai/observation_scorer.ts
+++ b/src/lib/ai/observation_scorer.ts
@@ -55,6 +55,19 @@ export interface WeatherCondition {
 
 // ---- Output types ----
 
+export type RecommendationCode =
+  | "excellent"
+  | "good_weather_issue"
+  | "good_moon_issue"
+  | "good_low_alt"
+  | "good"
+  | "challenging"
+  | "below_horizon"
+  | "poor_weather"
+  | "marginal"
+  | "too_faint"
+  | "poor";
+
 export interface ObservationScore {
   /** Overall score 0-100 */
   overall: number;
@@ -68,8 +81,10 @@ export interface ObservationScore {
     /** Target difficulty score 0-100 (100 = easy target) */
     targetDifficulty: number;
   };
-  /** Short recommendation text */
+  /** Short recommendation text (English) */
   recommendation: string;
+  /** Stable code for i18n lookup */
+  recommendationCode: RecommendationCode;
 }
 
 // ---- Scoring weights ----
@@ -201,30 +216,36 @@ export function scoreTargetDifficulty(
   return Math.round(Math.max(0, Math.min(100, score)));
 }
 
+interface RecommendationResult {
+  text: string;
+  code: RecommendationCode;
+}
+
 /**
- * Generate a recommendation string based on scores.
+ * Generate a recommendation based on scores.
+ * Returns both a human-readable text and a stable code for i18n.
  */
 export function generateRecommendation(
   overall: number,
   factors: ObservationScore["factors"],
   altitudeDeg: number
-): string {
-  if (overall >= 80) return "Excellent conditions. Highly recommended.";
+): RecommendationResult {
+  if (overall >= 80) return { text: "Excellent conditions. Highly recommended.", code: "excellent" };
   if (overall >= 60) {
-    if (factors.weather < 50) return "Good target, but weather may interfere.";
-    if (factors.moonImpact < 50) return "Good target, but moonlight will reduce contrast.";
-    if (factors.altitude < 50) return "Good target, wait for higher altitude.";
-    return "Good conditions for observation.";
+    if (factors.weather < 50) return { text: "Good target, but weather may interfere.", code: "good_weather_issue" };
+    if (factors.moonImpact < 50) return { text: "Good target, but moonlight will reduce contrast.", code: "good_moon_issue" };
+    if (factors.altitude < 50) return { text: "Good target, wait for higher altitude.", code: "good_low_alt" };
+    return { text: "Good conditions for observation.", code: "good" };
   }
   if (overall >= 40) {
-    if (factors.targetDifficulty < 30) return "Challenging target for this equipment.";
-    if (altitudeDeg <= 0) return "Target is below the horizon.";
-    if (factors.weather < 30) return "Poor weather conditions. Consider postponing.";
-    return "Marginal conditions. Results may vary.";
+    if (factors.targetDifficulty < 30) return { text: "Challenging target for this equipment.", code: "challenging" };
+    if (altitudeDeg <= 0) return { text: "Target is below the horizon.", code: "below_horizon" };
+    if (factors.weather < 30) return { text: "Poor weather conditions. Consider postponing.", code: "poor_weather" };
+    return { text: "Marginal conditions. Results may vary.", code: "marginal" };
   }
-  if (altitudeDeg <= 0) return "Target is below the horizon.";
-  if (factors.targetDifficulty === 0) return "Target is too faint for this equipment.";
-  return "Poor conditions. Not recommended.";
+  if (altitudeDeg <= 0) return { text: "Target is below the horizon.", code: "below_horizon" };
+  if (factors.targetDifficulty === 0) return { text: "Target is too faint for this equipment.", code: "too_faint" };
+  return { text: "Poor conditions. Not recommended.", code: "poor" };
 }
 
 /**
@@ -251,11 +272,11 @@ export function calculateObservationScore(
     factors.targetDifficulty * WEIGHTS.targetDifficulty
   );
 
-  const recommendation = generateRecommendation(
+  const { text: recommendation, code: recommendationCode } = generateRecommendation(
     overall,
     factors,
     position.altitudeDeg
   );
 
-  return { overall, factors, recommendation };
+  return { overall, factors, recommendation, recommendationCode };
 }

--- a/src/lib/ai/observation_scorer.ts
+++ b/src/lib/ai/observation_scorer.ts
@@ -230,6 +230,10 @@ export function generateRecommendation(
   factors: ObservationScore["factors"],
   altitudeDeg: number
 ): RecommendationResult {
+  // Priority checks: these conditions override any overall score
+  if (altitudeDeg <= 0) return { text: "Target is below the horizon.", code: "below_horizon" };
+  if (factors.targetDifficulty === 0) return { text: "Target is too faint for this equipment.", code: "too_faint" };
+
   if (overall >= 80) return { text: "Excellent conditions. Highly recommended.", code: "excellent" };
   if (overall >= 60) {
     if (factors.weather < 50) return { text: "Good target, but weather may interfere.", code: "good_weather_issue" };
@@ -239,12 +243,9 @@ export function generateRecommendation(
   }
   if (overall >= 40) {
     if (factors.targetDifficulty < 30) return { text: "Challenging target for this equipment.", code: "challenging" };
-    if (altitudeDeg <= 0) return { text: "Target is below the horizon.", code: "below_horizon" };
     if (factors.weather < 30) return { text: "Poor weather conditions. Consider postponing.", code: "poor_weather" };
     return { text: "Marginal conditions. Results may vary.", code: "marginal" };
   }
-  if (altitudeDeg <= 0) return { text: "Target is below the horizon.", code: "below_horizon" };
-  if (factors.targetDifficulty === 0) return { text: "Target is too faint for this equipment.", code: "too_faint" };
   return { text: "Poor conditions. Not recommended.", code: "poor" };
 }
 

--- a/src/lib/ai/observation_scorer.ts
+++ b/src/lib/ai/observation_scorer.ts
@@ -279,5 +279,11 @@ export function calculateObservationScore(
     position.altitudeDeg
   );
 
-  return { overall, factors, recommendation, recommendationCode };
+  // Clamp overall for hard-stop conditions so UI colors match recommendation
+  const displayOverall =
+    recommendationCode === "below_horizon" || recommendationCode === "too_faint"
+      ? 0
+      : overall;
+
+  return { overall: displayOverall, factors, recommendation, recommendationCode };
 }

--- a/src/lib/ai/tonights_best.ts
+++ b/src/lib/ai/tonights_best.ts
@@ -1,0 +1,117 @@
+/**
+ * Tonight's Best — ranks DSO targets for current observing session.
+ * Iterates the catalog, computes alt/az, scores each, returns top N.
+ */
+
+import type { AstroObject } from "@/types";
+import type {
+  WeatherCondition,
+  MoonCondition,
+  DsoTypeCategory,
+} from "./observation_scorer";
+import { calculateObservationScore } from "./observation_scorer";
+import type { EquipmentProfile } from "./equipment_profiles";
+import { computeRaDecToAltAz } from "@/lib/astro_utils";
+import {
+  convertHMSToDecimalDegrees,
+  convertDMSToDecimalDegrees,
+} from "@/lib/math_utils";
+import { toIsoStringInLocalTime } from "@/lib/date_utils";
+
+export interface RankedTarget {
+  object: AstroObject;
+  score: number;
+  altitudeDeg: number;
+  azimuthDeg: number;
+  recommendation: string;
+}
+
+export interface RankOptions {
+  /** Maximum number of results (default 20) */
+  limit?: number;
+  /** Minimum altitude to include (default 10) */
+  minAltitudeDeg?: number;
+  /** Minimum score to include (default 0) */
+  minScore?: number;
+}
+
+function parseObjectMagnitude(mag: string | number | null): number | null {
+  if (mag === null || mag === undefined) return null;
+  const num = typeof mag === "string" ? parseFloat(mag) : mag;
+  return isNaN(num) ? null : num;
+}
+
+function parseAngularSize(sizeStr?: string): number | null {
+  if (!sizeStr) return null;
+  const match = sizeStr.match(/^([\d.]+)/);
+  return match ? parseFloat(match[1]) : null;
+}
+
+/**
+ * Rank DSO targets for tonight based on current conditions.
+ * Objects below minAltitude are excluded.
+ */
+export function rankTargetsForTonight(
+  objects: AstroObject[],
+  lat: number,
+  lon: number,
+  timezone: string | undefined,
+  weather: WeatherCondition,
+  moon: MoonCondition,
+  equipment: EquipmentProfile,
+  options: RankOptions = {}
+): RankedTarget[] {
+  const { limit = 20, minAltitudeDeg = 10, minScore = 0 } = options;
+  const now = new Date();
+  const dateStr = toIsoStringInLocalTime(now);
+
+  const ranked: RankedTarget[] = [];
+
+  for (const obj of objects) {
+    // Skip objects without coordinates
+    if (!obj.ra || !obj.dec) continue;
+
+    const raDecimal = convertHMSToDecimalDegrees(obj.ra);
+    const decDecimal = convertDMSToDecimalDegrees(obj.dec);
+    if (!raDecimal || !decDecimal) continue;
+
+    const altAz = computeRaDecToAltAz(
+      lat,
+      lon,
+      raDecimal,
+      decDecimal,
+      dateStr,
+      timezone
+    );
+    if (!altAz || altAz.alt < minAltitudeDeg) continue;
+
+    const magnitude = parseObjectMagnitude(obj.magnitude);
+
+    const score = calculateObservationScore(
+      {
+        magnitude,
+        angularSizeArcmin: parseAngularSize(obj.size),
+        typeCategory: (obj.typeCategory || "other") as DsoTypeCategory,
+      },
+      { altitudeDeg: altAz.alt, azimuthDeg: altAz.az },
+      moon,
+      weather,
+      equipment
+    );
+
+    if (score.overall < minScore) continue;
+
+    ranked.push({
+      object: obj,
+      score: score.overall,
+      altitudeDeg: Math.round(altAz.alt * 10) / 10,
+      azimuthDeg: Math.round(altAz.az * 10) / 10,
+      recommendation: score.recommendation,
+    });
+  }
+
+  // Sort by score descending
+  ranked.sort((a, b) => b.score - a.score);
+
+  return ranked.slice(0, limit);
+}

--- a/src/lib/ai/tonights_best.ts
+++ b/src/lib/ai/tonights_best.ts
@@ -73,7 +73,7 @@ export function rankTargetsForTonight(
 
     const raDecimal = convertHMSToDecimalDegrees(obj.ra);
     const decDecimal = convertDMSToDecimalDegrees(obj.dec);
-    if (!raDecimal || !decDecimal) continue;
+    if (isNaN(raDecimal) || isNaN(decDecimal)) continue;
 
     const altAz = computeRaDecToAltAz(
       lat,

--- a/src/lib/astro_utils.ts
+++ b/src/lib/astro_utils.ts
@@ -500,7 +500,7 @@ function calc_jd(date: string, timeZone: string = "") {
       })
       .split(/GMT/g)[1];
     console.debug("time b :" + b);
-    offsetTimeZone = Number(b) - Number(a);
+    let offsetTimeZone = Number(b) - Number(a);
     console.debug("Offset: " + offsetTimeZone);
   }
 

--- a/src/lib/astro_utils.ts
+++ b/src/lib/astro_utils.ts
@@ -500,7 +500,7 @@ function calc_jd(date: string, timeZone: string = "") {
       })
       .split(/GMT/g)[1];
     console.debug("time b :" + b);
-    let offsetTimeZone = Number(b) - Number(a);
+    offsetTimeZone = Number(b) - Number(a);
     console.debug("Offset: " + offsetTimeZone);
   }
 

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -430,5 +430,10 @@
   "cAiRecPoorWeather": "Schlechte Wetterbedingungen. Verschiebung empfohlen.",
   "cAiRecMarginal": "Grenzwertige Bedingungen. Ergebnisse können variieren.",
   "cAiRecTooFaint": "Ziel ist zu lichtschwach für diese Ausrüstung.",
-  "cAiRecPoor": "Schlechte Bedingungen. Nicht empfohlen."
+  "cAiRecPoor": "Schlechte Bedingungen. Nicht empfohlen.",
+  "pTonightsBest": "Beste Objekte",
+  "cAiTonightTitle": "Beste Ziele für heute Nacht",
+  "cAiTonightRefresh": "Aktualisieren",
+  "cAiTonightNoLocation": "Standort festlegen, um die besten Ziele zu sehen.",
+  "cAiTonightEmpty": "Derzeit sind keine Ziele sichtbar. Versuchen Sie es später erneut."
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -413,5 +413,22 @@
   "cRemoveFromPersonalListButton": "Objekt entfernen",
   "cRemoveFromPersonalListConfirm": "Sind Sie sicher, dass Sie dieses Objekt entfernen möchten?",
   "cRemoveFromPersonalListTitle": "Entfernen Sie das Objekt aus meiner persönlichen Bibliothek",
-  "pMediaMtxNeedOpenPort8888": "Sie müssen jedoch Port 8888 auf dem Proxy Lan Router geöffnet haben."
+  "pMediaMtxNeedOpenPort8888": "Sie müssen jedoch Port 8888 auf dem Proxy Lan Router geöffnet haben.",
+  "cAiScoreTitle": "Beobachtungsbewertung",
+  "cAiScoreLoading": "Bedingungen werden geladen...",
+  "cAiScoreAltitude": "Höhe",
+  "cAiScoreWeather": "Wetter",
+  "cAiScoreMoon": "Mond",
+  "cAiScoreDifficulty": "Schwierigkeit",
+  "cAiRecExcellent": "Ausgezeichnete Bedingungen. Sehr empfehlenswert.",
+  "cAiRecWeatherIssue": "Gutes Ziel, aber das Wetter könnte stören.",
+  "cAiRecMoonIssue": "Gutes Ziel, aber Mondlicht verringert den Kontrast.",
+  "cAiRecLowAlt": "Gutes Ziel, auf größere Höhe warten.",
+  "cAiRecGood": "Gute Bedingungen für die Beobachtung.",
+  "cAiRecChallenging": "Anspruchsvolles Ziel für diese Ausrüstung.",
+  "cAiRecBelowHorizon": "Ziel befindet sich unter dem Horizont.",
+  "cAiRecPoorWeather": "Schlechte Wetterbedingungen. Verschiebung empfohlen.",
+  "cAiRecMarginal": "Grenzwertige Bedingungen. Ergebnisse können variieren.",
+  "cAiRecTooFaint": "Ziel ist zu lichtschwach für diese Ausrüstung.",
+  "cAiRecPoor": "Schlechte Bedingungen. Nicht empfohlen."
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -430,5 +430,10 @@
   "cAiRecPoorWeather": "Poor weather conditions. Consider postponing.",
   "cAiRecMarginal": "Marginal conditions. Results may vary.",
   "cAiRecTooFaint": "Target is too faint for this equipment.",
-  "cAiRecPoor": "Poor conditions. Not recommended."
+  "cAiRecPoor": "Poor conditions. Not recommended.",
+  "pTonightsBest": "Tonight's Best",
+  "cAiTonightTitle": "Tonight's Best Targets",
+  "cAiTonightRefresh": "Refresh",
+  "cAiTonightNoLocation": "Set your location to see tonight's best targets.",
+  "cAiTonightEmpty": "No targets are currently visible. Try again later."
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -413,5 +413,22 @@
   "cObjectsRemovePersonal": "Want to remove the Object from your Personal Library?",
   "cRemoveFromPersonalListTitle": "Remove Object from My Personal Library",
   "cRemoveFromPersonalListConfirm": "Are you sure you want to remove this object",
-  "cRemoveFromPersonalListButton": "Remove Object"
+  "cRemoveFromPersonalListButton": "Remove Object",
+  "cAiScoreTitle": "Observation Score",
+  "cAiScoreLoading": "Loading conditions...",
+  "cAiScoreAltitude": "Altitude",
+  "cAiScoreWeather": "Weather",
+  "cAiScoreMoon": "Moon",
+  "cAiScoreDifficulty": "Difficulty",
+  "cAiRecExcellent": "Excellent conditions. Highly recommended.",
+  "cAiRecWeatherIssue": "Good target, but weather may interfere.",
+  "cAiRecMoonIssue": "Good target, but moonlight will reduce contrast.",
+  "cAiRecLowAlt": "Good target, wait for higher altitude.",
+  "cAiRecGood": "Good conditions for observation.",
+  "cAiRecChallenging": "Challenging target for this equipment.",
+  "cAiRecBelowHorizon": "Target is below the horizon.",
+  "cAiRecPoorWeather": "Poor weather conditions. Consider postponing.",
+  "cAiRecMarginal": "Marginal conditions. Results may vary.",
+  "cAiRecTooFaint": "Target is too faint for this equipment.",
+  "cAiRecPoor": "Poor conditions. Not recommended."
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -430,5 +430,10 @@
   "cAiRecPoorWeather": "Malas condiciones climáticas. Considere posponer.",
   "cAiRecMarginal": "Condiciones marginales. Los resultados pueden variar.",
   "cAiRecTooFaint": "Objetivo demasiado tenue para este equipo.",
-  "cAiRecPoor": "Malas condiciones. No recomendado."
+  "cAiRecPoor": "Malas condiciones. No recomendado.",
+  "pTonightsBest": "Mejores objetos",
+  "cAiTonightTitle": "Mejores objetivos de esta noche",
+  "cAiTonightRefresh": "Actualizar",
+  "cAiTonightNoLocation": "Establece tu ubicación para ver los mejores objetivos.",
+  "cAiTonightEmpty": "No hay objetivos visibles actualmente. Inténtelo más tarde."
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -413,5 +413,22 @@
   "cRemoveFromPersonalListButton": "Eliminar objeto",
   "cRemoveFromPersonalListConfirm": "¿Estás seguro de que quieres eliminar este objeto?",
   "cRemoveFromPersonalListTitle": "Eliminar objeto de mi biblioteca personal",
-  "pMediaMtxNeedOpenPort8888": "Pero debe tener el puerto 8888 abierto en el enrutador de LAN proxy."
+  "pMediaMtxNeedOpenPort8888": "Pero debe tener el puerto 8888 abierto en el enrutador de LAN proxy.",
+  "cAiScoreTitle": "Puntuación de observación",
+  "cAiScoreLoading": "Cargando condiciones...",
+  "cAiScoreAltitude": "Altitud",
+  "cAiScoreWeather": "Clima",
+  "cAiScoreMoon": "Luna",
+  "cAiScoreDifficulty": "Dificultad",
+  "cAiRecExcellent": "Condiciones excelentes. Muy recomendado.",
+  "cAiRecWeatherIssue": "Buen objetivo, pero el clima podría interferir.",
+  "cAiRecMoonIssue": "Buen objetivo, pero la luz de la luna reducirá el contraste.",
+  "cAiRecLowAlt": "Buen objetivo, esperar mayor altitud.",
+  "cAiRecGood": "Buenas condiciones para la observación.",
+  "cAiRecChallenging": "Objetivo desafiante para este equipo.",
+  "cAiRecBelowHorizon": "El objetivo está bajo el horizonte.",
+  "cAiRecPoorWeather": "Malas condiciones climáticas. Considere posponer.",
+  "cAiRecMarginal": "Condiciones marginales. Los resultados pueden variar.",
+  "cAiRecTooFaint": "Objetivo demasiado tenue para este equipo.",
+  "cAiRecPoor": "Malas condiciones. No recomendado."
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -413,5 +413,22 @@
   "cRemoveFromPersonalListButton": "Supprimer l'objet",
   "cRemoveFromPersonalListConfirm": "Êtes-vous sûr de vouloir supprimer cet objet",
   "cRemoveFromPersonalListTitle": "Supprimer l'objet de ma bibliothèque personnelle",
-  "pMediaMtxNeedOpenPort8888": "Mais vous devez avoir le port 8888 ouvert sur le routeur LAN proxy."
+  "pMediaMtxNeedOpenPort8888": "Mais vous devez avoir le port 8888 ouvert sur le routeur LAN proxy.",
+  "cAiScoreTitle": "Score d'observation",
+  "cAiScoreLoading": "Chargement des conditions...",
+  "cAiScoreAltitude": "Altitude",
+  "cAiScoreWeather": "Météo",
+  "cAiScoreMoon": "Lune",
+  "cAiScoreDifficulty": "Difficulté",
+  "cAiRecExcellent": "Conditions excellentes. Fortement recommandé.",
+  "cAiRecWeatherIssue": "Bonne cible, mais la météo pourrait gêner.",
+  "cAiRecMoonIssue": "Bonne cible, mais le clair de lune réduira le contraste.",
+  "cAiRecLowAlt": "Bonne cible, attendre une altitude plus élevée.",
+  "cAiRecGood": "Bonnes conditions d'observation.",
+  "cAiRecChallenging": "Cible difficile pour cet équipement.",
+  "cAiRecBelowHorizon": "La cible est sous l'horizon.",
+  "cAiRecPoorWeather": "Mauvaises conditions météo. Envisagez de reporter.",
+  "cAiRecMarginal": "Conditions limites. Les résultats peuvent varier.",
+  "cAiRecTooFaint": "Cible trop faible pour cet équipement.",
+  "cAiRecPoor": "Mauvaises conditions. Non recommandé."
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -430,5 +430,10 @@
   "cAiRecPoorWeather": "Mauvaises conditions météo. Envisagez de reporter.",
   "cAiRecMarginal": "Conditions limites. Les résultats peuvent varier.",
   "cAiRecTooFaint": "Cible trop faible pour cet équipement.",
-  "cAiRecPoor": "Mauvaises conditions. Non recommandé."
+  "cAiRecPoor": "Mauvaises conditions. Non recommandé.",
+  "pTonightsBest": "Meilleurs objets",
+  "cAiTonightTitle": "Meilleurs objets ce soir",
+  "cAiTonightRefresh": "Rafraîchir",
+  "cAiTonightNoLocation": "Définissez votre position pour voir les meilleurs objets.",
+  "cAiTonightEmpty": "Aucun objet visible actuellement. Réessayez plus tard."
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -430,5 +430,10 @@
   "cAiRecPoorWeather": "Cattive condizioni meteo. Considerare di rimandare.",
   "cAiRecMarginal": "Condizioni marginali. I risultati possono variare.",
   "cAiRecTooFaint": "Obiettivo troppo debole per questa attrezzatura.",
-  "cAiRecPoor": "Cattive condizioni. Non raccomandato."
+  "cAiRecPoor": "Cattive condizioni. Non raccomandato.",
+  "pTonightsBest": "Migliori oggetti",
+  "cAiTonightTitle": "Migliori obiettivi di stasera",
+  "cAiTonightRefresh": "Aggiorna",
+  "cAiTonightNoLocation": "Imposta la tua posizione per vedere i migliori obiettivi.",
+  "cAiTonightEmpty": "Nessun obiettivo visibile al momento. Riprova più tardi."
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -413,5 +413,22 @@
   "cRemoveFromPersonalListButton": "Rimuovere l'oggetto",
   "cRemoveFromPersonalListConfirm": "Sei sicuro di voler rimuovere questo oggetto",
   "cRemoveFromPersonalListTitle": "Rimuovi l'oggetto dalla mia libreria personale",
-  "pMediaMtxNeedOpenPort8888": "Ma devi aprire la porta 8888 sul router LAN proxy."
+  "pMediaMtxNeedOpenPort8888": "Ma devi aprire la porta 8888 sul router LAN proxy.",
+  "cAiScoreTitle": "Punteggio di osservazione",
+  "cAiScoreLoading": "Caricamento condizioni...",
+  "cAiScoreAltitude": "Altitudine",
+  "cAiScoreWeather": "Meteo",
+  "cAiScoreMoon": "Luna",
+  "cAiScoreDifficulty": "Difficoltà",
+  "cAiRecExcellent": "Condizioni eccellenti. Altamente raccomandato.",
+  "cAiRecWeatherIssue": "Buon obiettivo, ma il meteo potrebbe interferire.",
+  "cAiRecMoonIssue": "Buon obiettivo, ma la luce lunare ridurrà il contrasto.",
+  "cAiRecLowAlt": "Buon obiettivo, attendere un'altitudine maggiore.",
+  "cAiRecGood": "Buone condizioni per l'osservazione.",
+  "cAiRecChallenging": "Obiettivo impegnativo per questa attrezzatura.",
+  "cAiRecBelowHorizon": "L'obiettivo è sotto l'orizzonte.",
+  "cAiRecPoorWeather": "Cattive condizioni meteo. Considerare di rimandare.",
+  "cAiRecMarginal": "Condizioni marginali. I risultati possono variare.",
+  "cAiRecTooFaint": "Obiettivo troppo debole per questa attrezzatura.",
+  "cAiRecPoor": "Cattive condizioni. Non raccomandato."
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -413,5 +413,22 @@
   "cObjectsRemovePersonal": "マイライブラリからこの天体を削除しますか？",
   "cRemoveFromPersonalListTitle": "マイライブラリから天体を削除",
   "cRemoveFromPersonalListConfirm": "本当にこの天体を削除しますか？",
-  "cRemoveFromPersonalListButton": "天体を削除"
+  "cRemoveFromPersonalListButton": "天体を削除",
+  "cAiScoreTitle": "観測スコア",
+  "cAiScoreLoading": "条件を読み込み中...",
+  "cAiScoreAltitude": "高度",
+  "cAiScoreWeather": "天候",
+  "cAiScoreMoon": "月明かり",
+  "cAiScoreDifficulty": "難易度",
+  "cAiRecExcellent": "絶好の条件です。強くおすすめします。",
+  "cAiRecWeatherIssue": "良い対象ですが、天候が影響する可能性があります。",
+  "cAiRecMoonIssue": "良い対象ですが、月明かりでコントラストが低下します。",
+  "cAiRecLowAlt": "良い対象です。高度が上がるまでお待ちください。",
+  "cAiRecGood": "観測に適した条件です。",
+  "cAiRecChallenging": "この機材では難しい対象です。",
+  "cAiRecBelowHorizon": "対象は地平線の下にあります。",
+  "cAiRecPoorWeather": "天候不良です。延期を検討してください。",
+  "cAiRecMarginal": "条件は限界的です。結果にばらつきが出る可能性があります。",
+  "cAiRecTooFaint": "この機材では暗すぎる対象です。",
+  "cAiRecPoor": "条件が悪いです。おすすめしません。"
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -430,5 +430,10 @@
   "cAiRecPoorWeather": "天候不良です。延期を検討してください。",
   "cAiRecMarginal": "条件は限界的です。結果にばらつきが出る可能性があります。",
   "cAiRecTooFaint": "この機材では暗すぎる対象です。",
-  "cAiRecPoor": "条件が悪いです。おすすめしません。"
+  "cAiRecPoor": "条件が悪いです。おすすめしません。",
+  "pTonightsBest": "今夜のおすすめ",
+  "cAiTonightTitle": "今夜のおすすめ天体",
+  "cAiTonightRefresh": "更新",
+  "cAiTonightNoLocation": "おすすめ天体を表示するには位置情報を設定してください。",
+  "cAiTonightEmpty": "現在見える天体がありません。後でもう一度お試しください。"
 }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -413,5 +413,22 @@
   "cRemoveFromPersonalListButton": "Verwijder object",
   "cRemoveFromPersonalListConfirm": "Weet je zeker dat je dit object wilt verwijderen",
   "cRemoveFromPersonalListTitle": "Verwijder het object uit mijn persoonlijke bibliotheek",
-  "pMediaMtxNeedOpenPort8888": "Maar u moet poort 8888 open hebben op de proxy LAN -router."
+  "pMediaMtxNeedOpenPort8888": "Maar u moet poort 8888 open hebben op de proxy LAN -router.",
+  "cAiScoreTitle": "Waarnemingsscore",
+  "cAiScoreLoading": "Omstandigheden laden...",
+  "cAiScoreAltitude": "Hoogte",
+  "cAiScoreWeather": "Weer",
+  "cAiScoreMoon": "Maan",
+  "cAiScoreDifficulty": "Moeilijkheid",
+  "cAiRecExcellent": "Uitstekende omstandigheden. Sterk aanbevolen.",
+  "cAiRecWeatherIssue": "Goed object, maar het weer kan hinderen.",
+  "cAiRecMoonIssue": "Goed object, maar maanlicht vermindert het contrast.",
+  "cAiRecLowAlt": "Goed object, wacht op een hogere hoogte.",
+  "cAiRecGood": "Goede omstandigheden voor waarneming.",
+  "cAiRecChallenging": "Uitdagend object voor deze apparatuur.",
+  "cAiRecBelowHorizon": "Object bevindt zich onder de horizon.",
+  "cAiRecPoorWeather": "Slechte weersomstandigheden. Overweeg uitstel.",
+  "cAiRecMarginal": "Marginale omstandigheden. Resultaten kunnen variëren.",
+  "cAiRecTooFaint": "Object is te zwak voor deze apparatuur.",
+  "cAiRecPoor": "Slechte omstandigheden. Niet aanbevolen."
 }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -430,5 +430,10 @@
   "cAiRecPoorWeather": "Slechte weersomstandigheden. Overweeg uitstel.",
   "cAiRecMarginal": "Marginale omstandigheden. Resultaten kunnen variëren.",
   "cAiRecTooFaint": "Object is te zwak voor deze apparatuur.",
-  "cAiRecPoor": "Slechte omstandigheden. Niet aanbevolen."
+  "cAiRecPoor": "Slechte omstandigheden. Niet aanbevolen.",
+  "pTonightsBest": "Beste objecten",
+  "cAiTonightTitle": "Beste objecten vanavond",
+  "cAiTonightRefresh": "Vernieuwen",
+  "cAiTonightNoLocation": "Stel uw locatie in om de beste objecten te zien.",
+  "cAiTonightEmpty": "Momenteel geen zichtbare objecten. Probeer het later opnieuw."
 }

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -413,5 +413,22 @@
   "cRemoveFromPersonalListButton": "Usuń obiekt",
   "cRemoveFromPersonalListConfirm": "Czy na pewno chcesz usunąć ten obiekt",
   "cRemoveFromPersonalListTitle": "Usuń obiekt z mojej osobistej biblioteki",
-  "pMediaMtxNeedOpenPort8888": "Ale musisz otworzyć port 8888 na router Proxy Lan."
+  "pMediaMtxNeedOpenPort8888": "Ale musisz otworzyć port 8888 na router Proxy Lan.",
+  "cAiScoreTitle": "Ocena obserwacji",
+  "cAiScoreLoading": "Ładowanie warunków...",
+  "cAiScoreAltitude": "Wysokość",
+  "cAiScoreWeather": "Pogoda",
+  "cAiScoreMoon": "Księżyc",
+  "cAiScoreDifficulty": "Trudność",
+  "cAiRecExcellent": "Doskonałe warunki. Gorąco polecane.",
+  "cAiRecWeatherIssue": "Dobry cel, ale pogoda może przeszkadzać.",
+  "cAiRecMoonIssue": "Dobry cel, ale światło księżyca zmniejszy kontrast.",
+  "cAiRecLowAlt": "Dobry cel, poczekaj na większą wysokość.",
+  "cAiRecGood": "Dobre warunki do obserwacji.",
+  "cAiRecChallenging": "Wymagający cel dla tego sprzętu.",
+  "cAiRecBelowHorizon": "Cel znajduje się poniżej horyzontu.",
+  "cAiRecPoorWeather": "Złe warunki pogodowe. Rozważ przełożenie.",
+  "cAiRecMarginal": "Graniczne warunki. Wyniki mogą się różnić.",
+  "cAiRecTooFaint": "Cel jest zbyt słaby dla tego sprzętu.",
+  "cAiRecPoor": "Złe warunki. Niezalecane."
 }

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -430,5 +430,10 @@
   "cAiRecPoorWeather": "Złe warunki pogodowe. Rozważ przełożenie.",
   "cAiRecMarginal": "Graniczne warunki. Wyniki mogą się różnić.",
   "cAiRecTooFaint": "Cel jest zbyt słaby dla tego sprzętu.",
-  "cAiRecPoor": "Złe warunki. Niezalecane."
+  "cAiRecPoor": "Złe warunki. Niezalecane.",
+  "pTonightsBest": "Najlepsze obiekty",
+  "cAiTonightTitle": "Najlepsze cele na dziś wieczór",
+  "cAiTonightRefresh": "Odśwież",
+  "cAiTonightNoLocation": "Ustaw swoją lokalizację, aby zobaczyć najlepsze cele.",
+  "cAiTonightEmpty": "Brak widocznych celów. Spróbuj ponownie później."
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -430,5 +430,10 @@
   "cAiRecPoorWeather": "Más condições climáticas. Considere adiar.",
   "cAiRecMarginal": "Condições marginais. Os resultados podem variar.",
   "cAiRecTooFaint": "Alvo muito fraco para este equipamento.",
-  "cAiRecPoor": "Más condições. Não recomendado."
+  "cAiRecPoor": "Más condições. Não recomendado.",
+  "pTonightsBest": "Melhores objetos",
+  "cAiTonightTitle": "Melhores alvos de hoje à noite",
+  "cAiTonightRefresh": "Atualizar",
+  "cAiTonightNoLocation": "Defina sua localização para ver os melhores alvos.",
+  "cAiTonightEmpty": "Nenhum alvo visível no momento. Tente novamente mais tarde."
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -413,5 +413,22 @@
   "cRemoveFromPersonalListButton": "Remova o objeto",
   "cRemoveFromPersonalListConfirm": "Tem certeza que deseja remover este objeto",
   "cRemoveFromPersonalListTitle": "Remova o objeto da minha biblioteca pessoal",
-  "pMediaMtxNeedOpenPort8888": "Mas você precisa ter a porta 8888 aberta no roteador proxy LAN."
+  "pMediaMtxNeedOpenPort8888": "Mas você precisa ter a porta 8888 aberta no roteador proxy LAN.",
+  "cAiScoreTitle": "Pontuação de observação",
+  "cAiScoreLoading": "Carregando condições...",
+  "cAiScoreAltitude": "Altitude",
+  "cAiScoreWeather": "Clima",
+  "cAiScoreMoon": "Lua",
+  "cAiScoreDifficulty": "Dificuldade",
+  "cAiRecExcellent": "Condições excelentes. Altamente recomendado.",
+  "cAiRecWeatherIssue": "Bom alvo, mas o clima pode interferir.",
+  "cAiRecMoonIssue": "Bom alvo, mas o luar reduzirá o contraste.",
+  "cAiRecLowAlt": "Bom alvo, aguarde uma altitude maior.",
+  "cAiRecGood": "Boas condições para observação.",
+  "cAiRecChallenging": "Alvo desafiador para este equipamento.",
+  "cAiRecBelowHorizon": "O alvo está abaixo do horizonte.",
+  "cAiRecPoorWeather": "Más condições climáticas. Considere adiar.",
+  "cAiRecMarginal": "Condições marginais. Os resultados podem variar.",
+  "cAiRecTooFaint": "Alvo muito fraco para este equipamento.",
+  "cAiRecPoor": "Más condições. Não recomendado."
 }

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -430,5 +430,10 @@
   "cAiRecPoorWeather": "天气条件差，建议推迟。",
   "cAiRecMarginal": "边际条件，结果可能有差异。",
   "cAiRecTooFaint": "目标对该设备来说太暗。",
-  "cAiRecPoor": "条件差，不推荐。"
+  "cAiRecPoor": "条件差，不推荐。",
+  "pTonightsBest": "今晚推荐",
+  "cAiTonightTitle": "今晚最佳观测目标",
+  "cAiTonightRefresh": "刷新",
+  "cAiTonightNoLocation": "请设置您的位置以查看推荐目标。",
+  "cAiTonightEmpty": "当前没有可见目标，请稍后再试。"
 }

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -413,5 +413,22 @@
   "cRemoveFromPersonalListButton": "删除对象",
   "cRemoveFromPersonalListConfirm": "您确定要删除此对象吗",
   "cRemoveFromPersonalListTitle": "从我的个人库中删除对象",
-  "pMediaMtxNeedOpenPort8888": "但是您需要在代理LAN路由器上打开端口8888。"
+  "pMediaMtxNeedOpenPort8888": "但是您需要在代理LAN路由器上打开端口8888。",
+  "cAiScoreTitle": "观测评分",
+  "cAiScoreLoading": "正在加载条件...",
+  "cAiScoreAltitude": "高度",
+  "cAiScoreWeather": "天气",
+  "cAiScoreMoon": "月光",
+  "cAiScoreDifficulty": "难度",
+  "cAiRecExcellent": "极佳条件，强烈推荐。",
+  "cAiRecWeatherIssue": "目标不错，但天气可能有影响。",
+  "cAiRecMoonIssue": "目标不错，但月光会降低对比度。",
+  "cAiRecLowAlt": "目标不错，请等待更高的高度。",
+  "cAiRecGood": "适合观测的良好条件。",
+  "cAiRecChallenging": "对该设备来说是个挑战性目标。",
+  "cAiRecBelowHorizon": "目标在地平线以下。",
+  "cAiRecPoorWeather": "天气条件差，建议推迟。",
+  "cAiRecMarginal": "边际条件，结果可能有差异。",
+  "cAiRecTooFaint": "目标对该设备来说太暗。",
+  "cAiRecPoor": "条件差，不推荐。"
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -19,6 +19,7 @@ import "@/styles/witsensordata.css";
 import "@/styles/mosaic.css";
 import "@/styles/sheduler.css";
 import "@/styles/camera.css";
+import "@/styles/ai-score-card.css";
 
 import "bootstrap-icons/font/bootstrap-icons.css";
 import "@/fontello/css/custom-focus.css";

--- a/src/pages/objects.tsx
+++ b/src/pages/objects.tsx
@@ -8,6 +8,7 @@ import GotoStellarium from "@/components/GotoStellarium";
 import GotoLists from "@/components/GotoLists";
 import GotoUserLists from "@/components/GotoUserLists";
 import Asteroids from "@/components/Asteroids";
+import TonightsBest from "@/components/ai/TonightsBest";
 import StatusBar from "@/components/shared/StatusBar";
 import CalibrationDwarf from "@/components/shared/CalibrationDwarf";
 import { useSetupConnection } from "@/hooks/useSetupConnection";
@@ -131,6 +132,14 @@ export default function Goto() {
           >
             Asteroids
           </li>
+          <li
+            className={`nav-item nav-link ${
+              connectionCtx.gotoType === "tonightsBest" ? "active" : ""
+            }`}
+            onClick={() => connectionCtx.setGotoType("tonightsBest")}
+          >
+            {t("pTonightsBest")}
+          </li>
         </ul>
         <hr />
         {connectionCtx.connectionStatus && connectionCtx.PiPView && (
@@ -189,6 +198,17 @@ export default function Goto() {
             setErrors={setErrors}
             setSuccess={setSuccess}
           ></Asteroids>
+        )}
+        {connectionCtx.gotoType === "tonightsBest" && (
+          <TonightsBest
+            objectFavoriteNames={objectFavoriteNames}
+            setObjectFavoriteNames={setObjectFavoriteNames}
+            objectPersonalList={objectPersonalList}
+            setObjectPersonalList={setObjectPersonalList}
+            setModule={setModule}
+            setErrors={setErrors}
+            setSuccess={setSuccess}
+          />
         )}
         <br />
         <br />

--- a/src/styles/ai-score-card.css
+++ b/src/styles/ai-score-card.css
@@ -1,0 +1,43 @@
+/* Observation Score Card — AI scoring display */
+
+.ai-score-card {
+  background-color: rgba(30, 30, 50, 0.6);
+  font-size: 0.85rem;
+}
+
+.ai-score-badge {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 1.1rem;
+  color: #fff;
+}
+
+.ai-score-good { background-color: #198754; }
+.ai-score-moderate { background-color: #ffc107; color: #000; }
+.ai-score-poor { background-color: #dc3545; }
+
+.ai-score-label {
+  width: 80px;
+  flex-shrink: 0;
+  margin-right: 6px;
+}
+
+.ai-score-bar {
+  height: 6px;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.ai-score-value {
+  width: 28px;
+  text-align: right;
+  margin-left: 6px;
+}
+
+.progress-bar.ai-score-good { background-color: #198754; }
+.progress-bar.ai-score-moderate { background-color: #ffc107; }
+.progress-bar.ai-score-poor { background-color: #dc3545; }


### PR DESCRIPTION
## Summary
- Add `tonights_best.ts` — ranks ~850 DSO catalog targets by observation score
- Add `TonightsBest.tsx` — new "Tonight's Best" tab on objects page
- 12 tests + 50 translations (5 keys × 10 locales)

## Details

### Core Logic (`src/lib/ai/tonights_best.ts`)
- `rankTargetsForTonight()` iterates the DSO catalog, computes alt/az for each
- Filters by minimum altitude (default 10°) and minimum score
- Sorts by overall observation score, returns top N (default 20)
- Uses same scoring as ObservationScoreCard

### UI Component (`src/components/ai/TonightsBest.tsx`)
- New tab in objects page navigation
- Shows ranked DSO list with score badge (rank # + score)
- Each entry renders via existing DSOObject component (with score card)
- Refresh button to recalculate
- Fallback UI for no location / loading / no visible targets

### Modified Files
- `src/pages/objects.tsx` — new tab + conditional render
- All 10 locale files — +5 keys each

## Dependencies
- PR #12 (feat/ai-observation-score-card) — score card UI
- PR #11 (feat/ai-weather-data-service) — weather/moon data
- PR #7 (feat/ai-observation-scorer) — scoring engine

## Test plan
- [x] 12 ranking tests pass
- [x] ESLint clean
- [x] Build succeeds
- [ ] Manual: "Tonight's Best" tab appears on objects page
- [ ] Manual: ranked list updates on refresh
- [ ] Manual: handles location not set gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)