### PR TITLE
fix: call setDeviceIdDwarf() in CMD_NOTIFY_STREAM_TYPE path

### DIFF
--- a/src/lib/connect_utils.ts
+++ b/src/lib/connect_utils.ts
@@ -301,14 +301,18 @@ export async function connectionHandler(
     } else if (result_data.cmd == Dwarfii_Api.DwarfCMD.CMD_NOTIFY_STREAM_TYPE) {
       if (result_data.data.camId == 0) {
         connectionCtx.setTypeIdDwarf(2);
-        connectionCtx.setTypeNameDwarf("Dwarf3");
-        webSocketHandler.setDeviceIdDwarf(2);
+        connectionCtx.setTypeNameDwarf(getDeviceName(2));
+        if (!webSocketHandler.setDeviceIdDwarf(2)) {
+          console.error("Failed to set device ID to 2 in CMD_NOTIFY_STREAM_TYPE (camId 0)");
+        }
         connectionCtx.setStreamTypeTeleDwarf(result_data.data.streamType);
         console.log("C setStreamTypeTeleDwarf: ", result_data.data.streamType);
       } else if (result_data.data.camId == 1) {
         connectionCtx.setTypeIdDwarf(2);
-        connectionCtx.setTypeNameDwarf("Dwarf3");
-        webSocketHandler.setDeviceIdDwarf(2);
+        connectionCtx.setTypeNameDwarf(getDeviceName(2));
+        if (!webSocketHandler.setDeviceIdDwarf(2)) {
+          console.error("Failed to set device ID to 2 in CMD_NOTIFY_STREAM_TYPE (camId 1)");
+        }
         connectionCtx.setStreamTypeWideDwarf(result_data.data.streamType);
         console.log("C setStreamTypeWideDwarf: ", result_data.data.streamType);
       }

--- a/src/lib/connect_utils.ts
+++ b/src/lib/connect_utils.ts
@@ -46,7 +46,10 @@ function updateAstroCamera(connectionCtx: ConnectionContextType, cmd) {
 }
 
 function getDeviceName(deviceId) {
-  return deviceId === 1 ? "Dwarf II" : deviceId === 2 ? "Dwarf3" : "Dwarf";
+  if (deviceId === 1) return "Dwarf II";
+  if (deviceId === 2) return "Dwarf3";
+  if (deviceId === 4) return "Dwarf Mini";
+  return "Dwarf";
 }
 
 export async function connectionHandler(
@@ -299,11 +302,13 @@ export async function connectionHandler(
       if (result_data.data.camId == 0) {
         connectionCtx.setTypeIdDwarf(2);
         connectionCtx.setTypeNameDwarf("Dwarf3");
+        webSocketHandler.setDeviceIdDwarf(2);
         connectionCtx.setStreamTypeTeleDwarf(result_data.data.streamType);
         console.log("C setStreamTypeTeleDwarf: ", result_data.data.streamType);
       } else if (result_data.data.camId == 1) {
         connectionCtx.setTypeIdDwarf(2);
         connectionCtx.setTypeNameDwarf("Dwarf3");
+        webSocketHandler.setDeviceIdDwarf(2);
         connectionCtx.setStreamTypeWideDwarf(result_data.data.streamType);
         console.log("C setStreamTypeWideDwarf: ", result_data.data.streamType);
       }


### PR DESCRIPTION
## Summary

- `CMD_NOTIFY_STREAM_TYPE` の検出パスで `webSocketHandler.setDeviceIdDwarf(2)` が呼ばれていなかったバグを修正
- DWARF 3 がストリームタイプ通知で検出された場合、WebSocketHandler 内部のデバイス ID が更新されず、以降のフレームが間違ったデバイス ID で送信される可能性があった
- `getDeviceName()` を読みやすくリファクタリングし、デバイス ID 4 (Dwarf Mini) のマッピングを追加 (#16 の準備)

## Changes

### `src/lib/connect_utils.ts`
1. **`CMD_NOTIFY_STREAM_TYPE` ハンドラ (camId 0 / camId 1)**: `webSocketHandler.setDeviceIdDwarf(2)` を追加 — メインの接続パス (line 126) と同じパターン
2. **`getDeviceName()`**: ネストした三項演算子を `if` 文に変更し、`deviceId === 4 → "Dwarf Mini"` を追加

## Test plan

- [x] `npx next lint` — No warnings or errors
- [x] `TZ=Europe/Paris npm run test` — 14 suites, 290 tests passed
- [x] `npx next build` — Compiled successfully
- [ ] 実機テスト不要 (ロジック的に安全な追加、既存パスのパターン踏襲)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)