### PR TITLE
fix: add Japanese to language dropdown

### DIFF
--- a/src/components/shared/Themesettings.tsx
+++ b/src/components/shared/Themesettings.tsx
@@ -45,6 +45,7 @@ const Modal: React.FC = () => {
     de: "Deutsch",
     es: "Español",
     it: "Italiano",
+    ja: "日本語",
     nl: "Nederlands",
     pl: "Polski",
     pt: "Português",


### PR DESCRIPTION
## Summary
- Japanese (ja) translation file and i18n config already exist, but `ja: "日本語"` was missing from the `languages` object in `Themesettings.tsx`
- This one-line fix adds Japanese to the language selector dropdown

## Background
Found during QA testing of AI features (Issue #15). All 10 target languages (de, en, es, fr, it, **ja**, nl, pl, pt, zh_CN) should be selectable, but Japanese was not appearing in the dropdown.

## Test plan
- [ ] Open Settings panel → Language dropdown now includes "日本語"
- [ ] Select 日本語 → UI switches to Japanese translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)