### PR TITLE
fix: add DWARF mini (deviceId=4) device support

### DIFF
--- a/src/components/DwarfCameras.tsx
+++ b/src/components/DwarfCameras.tsx
@@ -38,6 +38,7 @@ import {
   turnOnTeleCameraFn,
   turnOnWideCameraFn,
 } from "@/lib/dwarf_utils";
+import { getDeviceName } from "@/lib/connect_utils";
 
 type PropType = {
   setExchangeCamerasStatus: Dispatch<SetStateAction<boolean>>;
@@ -194,7 +195,7 @@ export default function DwarfCameras(props: PropType) {
       }
       console.info(
         `Device type read: ${connectionCtx.typeIdDwarf} - ${
-          connectionCtx.typeIdDwarf === 1 ? "Dwarf II" : "Dwarf 3"
+          getDeviceName(connectionCtx.typeIdDwarf)
         }`
       );
       console.debug("End Of Effect DwarfCameras");
@@ -510,7 +511,7 @@ export default function DwarfCameras(props: PropType) {
     ) {
       return wideAngleURL;
     } else {
-      // wideAngleURL_D3
+      // DWARF3 and DWARF Mini use RTSP streaming
       return wideAngleURL_D3;
     }
   }
@@ -529,7 +530,7 @@ export default function DwarfCameras(props: PropType) {
     ) {
       return telePhotoURL;
     } else {
-      // telePhotoURL_D3
+      // DWARF3 and DWARF Mini use RTSP streaming
       return telePhotoURL_D3;
     }
   }

--- a/src/lib/connect_utils.ts
+++ b/src/lib/connect_utils.ts
@@ -45,7 +45,7 @@ function updateAstroCamera(connectionCtx: ConnectionContextType, cmd) {
   }
 }
 
-function getDeviceName(deviceId) {
+export function getDeviceName(deviceId) {
   if (deviceId === 1) return "Dwarf II";
   if (deviceId === 2) return "Dwarf3";
   if (deviceId === 4) return "Dwarf Mini";

--- a/src/lib/data_dwarf_mini_config.ts
+++ b/src/lib/data_dwarf_mini_config.ts
@@ -1,0 +1,1734 @@
+// DWARF mini camera parameter configuration
+// Extracted from actual device HTTP API (/shootingMode/getParamAndSetting)
+// Device: DWARF mini, deviceId=4, FW 1.0.25.2
+// Source: pcap capture iphone-capture4-modes.pcap (modeId=1 & modeId=2)
+export const data_dwarf_mini_config = {
+  code: 0,
+  data: {
+    cameras: [
+      {
+        fvHeight: 1.794,
+        fvWidth: 3.188,
+        id: 0,
+        name: "Tele",
+        previewHeight: 1080,
+        previewWidth: 1920,
+        supportParams: [
+          {
+            autoMode: 0,
+            continueMode: {
+              defaultValue: 5,
+              max: 15,
+              min: 0,
+              step: 0,
+              valueType: 1,
+            },
+            defaultModeIndex: 0,
+            gearMode: {
+              defaultValueIndex: 30,
+              values: [
+              {
+                index: 0,
+                name: "1/10000",
+              },
+              {
+                index: 3,
+                name: "1/8000",
+              },
+              {
+                index: 6,
+                name: "1/6400",
+              },
+              {
+                index: 9,
+                name: "1/5000",
+              },
+              {
+                index: 12,
+                name: "1/4000",
+              },
+              {
+                index: 15,
+                name: "1/3200",
+              },
+              {
+                index: 18,
+                name: "1/2500",
+              },
+              {
+                index: 21,
+                name: "1/2000",
+              },
+              {
+                index: 24,
+                name: "1/1600",
+              },
+              {
+                index: 27,
+                name: "1/1250",
+              },
+              {
+                index: 30,
+                name: "1/1000",
+              },
+              {
+                index: 33,
+                name: "1/800",
+              },
+              {
+                index: 36,
+                name: "1/640",
+              },
+              {
+                index: 39,
+                name: "1/500",
+              },
+              {
+                index: 42,
+                name: "1/400",
+              },
+              {
+                index: 45,
+                name: "1/320",
+              },
+              {
+                index: 48,
+                name: "1/250",
+              },
+              {
+                index: 51,
+                name: "1/200",
+              },
+              {
+                index: 54,
+                name: "1/160",
+              },
+              {
+                index: 57,
+                name: "1/125",
+              },
+              {
+                index: 60,
+                name: "1/100",
+              },
+              {
+                index: 63,
+                name: "1/80",
+              },
+              {
+                index: 66,
+                name: "1/60",
+              },
+              {
+                index: 69,
+                name: "1/50",
+              },
+              {
+                index: 72,
+                name: "1/40",
+              },
+              {
+                index: 75,
+                name: "1/30",
+              },
+              {
+                index: 78,
+                name: "1/25",
+              },
+              {
+                index: 81,
+                name: "1/20",
+              },
+              {
+                index: 84,
+                name: "1/15",
+              },
+              {
+                index: 87,
+                name: "1/13",
+              },
+              {
+                index: 90,
+                name: "1/10",
+              },
+              {
+                index: 93,
+                name: "1/8",
+              },
+              {
+                index: 96,
+                name: "1/6",
+              },
+              {
+                index: 99,
+                name: "1/5",
+              },
+              {
+                index: 102,
+                name: "1/4",
+              },
+              {
+                index: 105,
+                name: "1/3",
+              },
+              {
+                index: 108,
+                name: "0.4",
+              },
+              {
+                index: 111,
+                name: "0.5",
+              },
+              {
+                index: 114,
+                name: "0.6",
+              },
+              {
+                index: 117,
+                name: "0.8",
+              },
+              {
+                index: 120,
+                name: "1",
+              },
+              {
+                index: 123,
+                name: "1.3",
+              },
+              {
+                index: 126,
+                name: "1.6",
+              },
+              {
+                index: 129,
+                name: "2",
+              },
+              {
+                index: 132,
+                name: "2.5",
+              },
+              {
+                index: 135,
+                name: "3.2",
+              },
+              {
+                index: 138,
+                name: "4",
+              },
+              {
+                index: 141,
+                name: "5",
+              },
+              {
+                index: 144,
+                name: "6",
+              },
+              {
+                index: 147,
+                name: "8",
+              },
+              {
+                index: 150,
+                name: "10",
+              },
+              {
+                index: 153,
+                name: "13",
+              },
+              {
+                index: 156,
+                name: "15",
+              },
+              {
+                index: 159,
+                name: "30",
+              },
+              {
+                index: 160,
+                name: "45",
+              },
+              {
+                index: 162,
+                name: "60",
+              },
+              {
+                index: 163,
+                name: "90",
+              },
+              {
+                index: 165,
+                name: "120",
+              },
+              {
+                index: 168,
+                name: "180",
+              },
+              ],
+            },
+            hasAuto: 0,
+            id: 0,
+            name: "Exposure",
+            supportMode: [0, 1],
+          },
+          {
+            autoMode: 0,
+            continueMode: {
+              defaultValue: 60,
+              max: 240,
+              min: 0,
+              step: 1,
+              valueType: 1,
+            },
+            defaultModeIndex: 0,
+            gearMode: {
+              defaultValueIndex: 60,
+              values: [
+              {
+                index: 0,
+                name: "0",
+              },
+              {
+                index: 2,
+                name: "2",
+              },
+              {
+                index: 5,
+                name: "5",
+              },
+              {
+                index: 10,
+                name: "10",
+              },
+              {
+                index: 20,
+                name: "20",
+              },
+              {
+                index: 30,
+                name: "30",
+              },
+              {
+                index: 40,
+                name: "40",
+              },
+              {
+                index: 50,
+                name: "50",
+              },
+              {
+                index: 60,
+                name: "60",
+              },
+              {
+                index: 70,
+                name: "70",
+              },
+              {
+                index: 80,
+                name: "80",
+              },
+              {
+                index: 90,
+                name: "90",
+              },
+              {
+                index: 100,
+                name: "100",
+              },
+              {
+                index: 110,
+                name: "110",
+              },
+              {
+                index: 120,
+                name: "120",
+              },
+              {
+                index: 130,
+                name: "130",
+              },
+              {
+                index: 140,
+                name: "140",
+              },
+              {
+                index: 150,
+                name: "150",
+              },
+              {
+                index: 160,
+                name: "160",
+              },
+              {
+                index: 170,
+                name: "170",
+              },
+              {
+                index: 180,
+                name: "180",
+              },
+              {
+                index: 190,
+                name: "190",
+              },
+              {
+                index: 200,
+                name: "200",
+              },
+              {
+                index: 210,
+                name: "210",
+              },
+              {
+                index: 220,
+                name: "220",
+              },
+              {
+                index: 230,
+                name: "230",
+              },
+              {
+                index: 240,
+                name: "240",
+              },
+              ],
+            },
+            hasAuto: 0,
+            id: 1,
+            name: "Gain",
+            supportMode: [0, 1],
+          },
+          {
+            autoMode: 0,
+            continueMode: {
+              defaultValue: 2800,
+              max: 7500,
+              min: 2800,
+              step: 100,
+              valueType: 1,
+            },
+            defaultModeIndex: 0,
+            gearMode: {
+              defaultValueIndex: 24,
+              values: [
+              {
+                index: 0,
+                name: "2800",
+              },
+              {
+                index: 1,
+                name: "2900",
+              },
+              {
+                index: 2,
+                name: "3000",
+              },
+              {
+                index: 3,
+                name: "3100",
+              },
+              {
+                index: 4,
+                name: "3200",
+              },
+              {
+                index: 5,
+                name: "3300",
+              },
+              {
+                index: 6,
+                name: "3400",
+              },
+              {
+                index: 7,
+                name: "3500",
+              },
+              {
+                index: 8,
+                name: "3600",
+              },
+              {
+                index: 9,
+                name: "3700",
+              },
+              {
+                index: 10,
+                name: "3800",
+              },
+              {
+                index: 11,
+                name: "3900",
+              },
+              {
+                index: 12,
+                name: "4000",
+              },
+              {
+                index: 13,
+                name: "4100",
+              },
+              {
+                index: 14,
+                name: "4200",
+              },
+              {
+                index: 15,
+                name: "4300",
+              },
+              {
+                index: 16,
+                name: "4400",
+              },
+              {
+                index: 17,
+                name: "4500",
+              },
+              {
+                index: 18,
+                name: "4600",
+              },
+              {
+                index: 19,
+                name: "4700",
+              },
+              {
+                index: 20,
+                name: "4800",
+              },
+              {
+                index: 21,
+                name: "4900",
+              },
+              {
+                index: 22,
+                name: "5000",
+              },
+              {
+                index: 23,
+                name: "5100",
+              },
+              {
+                index: 24,
+                name: "5200",
+              },
+              {
+                index: 25,
+                name: "5300",
+              },
+              {
+                index: 26,
+                name: "5400",
+              },
+              {
+                index: 27,
+                name: "5500",
+              },
+              {
+                index: 28,
+                name: "5600",
+              },
+              {
+                index: 29,
+                name: "5700",
+              },
+              {
+                index: 30,
+                name: "5800",
+              },
+              {
+                index: 31,
+                name: "5900",
+              },
+              {
+                index: 32,
+                name: "6000",
+              },
+              {
+                index: 33,
+                name: "6100",
+              },
+              {
+                index: 34,
+                name: "6200",
+              },
+              {
+                index: 35,
+                name: "6300",
+              },
+              {
+                index: 36,
+                name: "6400",
+              },
+              {
+                index: 37,
+                name: "6500",
+              },
+              {
+                index: 38,
+                name: "6600",
+              },
+              {
+                index: 39,
+                name: "6700",
+              },
+              {
+                index: 40,
+                name: "6800",
+              },
+              {
+                index: 41,
+                name: "6900",
+              },
+              {
+                index: 42,
+                name: "7000",
+              },
+              {
+                index: 43,
+                name: "7100",
+              },
+              {
+                index: 44,
+                name: "7200",
+              },
+              {
+                index: 45,
+                name: "7300",
+              },
+              {
+                index: 46,
+                name: "7400",
+              },
+              {
+                index: 47,
+                name: "7500",
+              },
+              ],
+            },
+            hasAuto: 0,
+            id: 2,
+            name: "WB",
+            supportMode: [0, 1, 2],
+          },
+          {
+            autoMode: 0,
+            continueMode: {
+              defaultValue: 0,
+              max: 1,
+              min: 0,
+              step: 1,
+              valueType: 1,
+            },
+            defaultModeIndex: 0,
+            gearMode: {
+              defaultValueIndex: 0,
+              values: [
+              {
+                index: 0,
+                name: "VIS Filter",
+              },
+              {
+                index: 1,
+                name: "Duo-Band Filter",
+              },
+              ],
+            },
+            hasAuto: 0,
+            id: 8,
+            name: "IR",
+            supportMode: [0],
+          },
+        ],
+      },
+      {
+        fvHeight: 1.794,
+        fvWidth: 3.188,
+        id: 1,
+        name: "Wide",
+        previewHeight: 1080,
+        previewWidth: 1920,
+        supportParams: [
+          {
+            autoMode: 0,
+            continueMode: {
+              defaultValue: 5,
+              max: 15,
+              min: 0,
+              step: 0,
+              valueType: 1,
+            },
+            defaultModeIndex: 0,
+            gearMode: {
+              defaultValueIndex: 30,
+              values: [
+              {
+                index: 0,
+                name: "1/10000",
+              },
+              {
+                index: 3,
+                name: "1/8000",
+              },
+              {
+                index: 6,
+                name: "1/6400",
+              },
+              {
+                index: 9,
+                name: "1/5000",
+              },
+              {
+                index: 12,
+                name: "1/4000",
+              },
+              {
+                index: 15,
+                name: "1/3200",
+              },
+              {
+                index: 18,
+                name: "1/2500",
+              },
+              {
+                index: 21,
+                name: "1/2000",
+              },
+              {
+                index: 24,
+                name: "1/1600",
+              },
+              {
+                index: 27,
+                name: "1/1250",
+              },
+              {
+                index: 30,
+                name: "1/1000",
+              },
+              {
+                index: 33,
+                name: "1/800",
+              },
+              {
+                index: 36,
+                name: "1/640",
+              },
+              {
+                index: 39,
+                name: "1/500",
+              },
+              {
+                index: 42,
+                name: "1/400",
+              },
+              {
+                index: 45,
+                name: "1/320",
+              },
+              {
+                index: 48,
+                name: "1/250",
+              },
+              {
+                index: 51,
+                name: "1/200",
+              },
+              {
+                index: 54,
+                name: "1/160",
+              },
+              {
+                index: 57,
+                name: "1/125",
+              },
+              {
+                index: 60,
+                name: "1/100",
+              },
+              {
+                index: 63,
+                name: "1/80",
+              },
+              {
+                index: 66,
+                name: "1/60",
+              },
+              {
+                index: 69,
+                name: "1/50",
+              },
+              {
+                index: 72,
+                name: "1/40",
+              },
+              {
+                index: 75,
+                name: "1/30",
+              },
+              {
+                index: 78,
+                name: "1/25",
+              },
+              {
+                index: 81,
+                name: "1/20",
+              },
+              {
+                index: 84,
+                name: "1/15",
+              },
+              {
+                index: 87,
+                name: "1/13",
+              },
+              {
+                index: 90,
+                name: "1/10",
+              },
+              {
+                index: 93,
+                name: "1/8",
+              },
+              {
+                index: 96,
+                name: "1/6",
+              },
+              {
+                index: 99,
+                name: "1/5",
+              },
+              {
+                index: 102,
+                name: "1/4",
+              },
+              {
+                index: 105,
+                name: "1/3",
+              },
+              {
+                index: 108,
+                name: "0.4",
+              },
+              {
+                index: 111,
+                name: "0.5",
+              },
+              {
+                index: 114,
+                name: "0.6",
+              },
+              {
+                index: 117,
+                name: "0.8",
+              },
+              {
+                index: 120,
+                name: "1",
+              },
+              {
+                index: 123,
+                name: "1.3",
+              },
+              {
+                index: 126,
+                name: "1.6",
+              },
+              {
+                index: 129,
+                name: "2",
+              },
+              {
+                index: 132,
+                name: "2.5",
+              },
+              {
+                index: 135,
+                name: "3.2",
+              },
+              {
+                index: 138,
+                name: "4",
+              },
+              {
+                index: 141,
+                name: "5",
+              },
+              {
+                index: 144,
+                name: "6",
+              },
+              {
+                index: 147,
+                name: "8",
+              },
+              {
+                index: 150,
+                name: "10",
+              },
+              {
+                index: 153,
+                name: "13",
+              },
+              {
+                index: 156,
+                name: "15",
+              },
+              {
+                index: 159,
+                name: "30",
+              },
+              ],
+            },
+            hasAuto: 0,
+            id: 0,
+            name: "Exposure",
+            supportMode: [0, 1],
+          },
+          {
+            autoMode: 0,
+            continueMode: {
+              defaultValue: 60,
+              max: 2500,
+              min: 40,
+              step: 1,
+              valueType: 1,
+            },
+            defaultModeIndex: 0,
+            gearMode: {
+              defaultValueIndex: 60,
+              values: [
+              {
+                index: 40,
+                name: "40",
+              },
+              {
+                index: 50,
+                name: "50",
+              },
+              {
+                index: 60,
+                name: "60",
+              },
+              {
+                index: 70,
+                name: "70",
+              },
+              {
+                index: 80,
+                name: "80",
+              },
+              {
+                index: 90,
+                name: "90",
+              },
+              {
+                index: 100,
+                name: "100",
+              },
+              {
+                index: 110,
+                name: "110",
+              },
+              {
+                index: 120,
+                name: "120",
+              },
+              {
+                index: 130,
+                name: "130",
+              },
+              {
+                index: 140,
+                name: "140",
+              },
+              {
+                index: 150,
+                name: "150",
+              },
+              {
+                index: 160,
+                name: "160",
+              },
+              {
+                index: 170,
+                name: "170",
+              },
+              {
+                index: 180,
+                name: "180",
+              },
+              {
+                index: 190,
+                name: "190",
+              },
+              {
+                index: 200,
+                name: "200",
+              },
+              {
+                index: 210,
+                name: "210",
+              },
+              {
+                index: 220,
+                name: "220",
+              },
+              {
+                index: 230,
+                name: "230",
+              },
+              {
+                index: 240,
+                name: "240",
+              },
+              {
+                index: 250,
+                name: "250",
+              },
+              {
+                index: 300,
+                name: "300",
+              },
+              {
+                index: 350,
+                name: "350",
+              },
+              {
+                index: 400,
+                name: "400",
+              },
+              {
+                index: 450,
+                name: "450",
+              },
+              {
+                index: 500,
+                name: "500",
+              },
+              {
+                index: 550,
+                name: "550",
+              },
+              {
+                index: 600,
+                name: "600",
+              },
+              {
+                index: 650,
+                name: "650",
+              },
+              {
+                index: 700,
+                name: "700",
+              },
+              {
+                index: 1000,
+                name: "1000",
+              },
+              {
+                index: 1300,
+                name: "1300",
+              },
+              {
+                index: 1600,
+                name: "1600",
+              },
+              {
+                index: 1900,
+                name: "1900",
+              },
+              {
+                index: 2200,
+                name: "2200",
+              },
+              {
+                index: 2500,
+                name: "2500",
+              },
+              ],
+            },
+            hasAuto: 0,
+            id: 1,
+            name: "Gain",
+            supportMode: [0, 1],
+          },
+          {
+            autoMode: 0,
+            continueMode: {
+              defaultValue: 2800,
+              max: 7500,
+              min: 2800,
+              step: 100,
+              valueType: 1,
+            },
+            defaultModeIndex: 0,
+            gearMode: {
+              defaultValueIndex: 24,
+              values: [
+              {
+                index: 0,
+                name: "2800",
+              },
+              {
+                index: 1,
+                name: "2900",
+              },
+              {
+                index: 2,
+                name: "3000",
+              },
+              {
+                index: 3,
+                name: "3100",
+              },
+              {
+                index: 4,
+                name: "3200",
+              },
+              {
+                index: 5,
+                name: "3300",
+              },
+              {
+                index: 6,
+                name: "3400",
+              },
+              {
+                index: 7,
+                name: "3500",
+              },
+              {
+                index: 8,
+                name: "3600",
+              },
+              {
+                index: 9,
+                name: "3700",
+              },
+              {
+                index: 10,
+                name: "3800",
+              },
+              {
+                index: 11,
+                name: "3900",
+              },
+              {
+                index: 12,
+                name: "4000",
+              },
+              {
+                index: 13,
+                name: "4100",
+              },
+              {
+                index: 14,
+                name: "4200",
+              },
+              {
+                index: 15,
+                name: "4300",
+              },
+              {
+                index: 16,
+                name: "4400",
+              },
+              {
+                index: 17,
+                name: "4500",
+              },
+              {
+                index: 18,
+                name: "4600",
+              },
+              {
+                index: 19,
+                name: "4700",
+              },
+              {
+                index: 20,
+                name: "4800",
+              },
+              {
+                index: 21,
+                name: "4900",
+              },
+              {
+                index: 22,
+                name: "5000",
+              },
+              {
+                index: 23,
+                name: "5100",
+              },
+              {
+                index: 24,
+                name: "5200",
+              },
+              {
+                index: 25,
+                name: "5300",
+              },
+              {
+                index: 26,
+                name: "5400",
+              },
+              {
+                index: 27,
+                name: "5500",
+              },
+              {
+                index: 28,
+                name: "5600",
+              },
+              {
+                index: 29,
+                name: "5700",
+              },
+              {
+                index: 30,
+                name: "5800",
+              },
+              {
+                index: 31,
+                name: "5900",
+              },
+              {
+                index: 32,
+                name: "6000",
+              },
+              {
+                index: 33,
+                name: "6100",
+              },
+              {
+                index: 34,
+                name: "6200",
+              },
+              {
+                index: 35,
+                name: "6300",
+              },
+              {
+                index: 36,
+                name: "6400",
+              },
+              {
+                index: 37,
+                name: "6500",
+              },
+              {
+                index: 38,
+                name: "6600",
+              },
+              {
+                index: 39,
+                name: "6700",
+              },
+              {
+                index: 40,
+                name: "6800",
+              },
+              {
+                index: 41,
+                name: "6900",
+              },
+              {
+                index: 42,
+                name: "7000",
+              },
+              {
+                index: 43,
+                name: "7100",
+              },
+              {
+                index: 44,
+                name: "7200",
+              },
+              {
+                index: 45,
+                name: "7300",
+              },
+              {
+                index: 46,
+                name: "7400",
+              },
+              {
+                index: 47,
+                name: "7500",
+              },
+              ],
+            },
+            hasAuto: 0,
+            id: 2,
+            name: "WB",
+            supportMode: [0, 1, 2],
+          },
+        ],
+      },
+    ],
+    featureParams: [
+      {
+        gearMode: {
+          defaultValueIndex: 0,
+          values: [
+            {
+              index: 0,
+              name: "4k",
+            },
+            {
+              index: 1,
+              name: "2k",
+            },
+          ],
+        },
+        id: 0,
+        name: "Astro binning",
+      },
+      {
+        autoMode: 0,
+        continueMode: {
+          defaultValue: 0,
+          max: 0,
+          min: 0,
+          step: 0,
+          valueType: 0,
+        },
+        defaultModeIndex: 0,
+        hasAuto: 0,
+        id: 1,
+        name: "Astro Exp Mode",
+        supportMode: [0],
+      },
+      {
+        gearMode: {
+          defaultValueIndex: 0,
+          values: [
+            {
+              index: 0,
+              name: "FITS",
+            },
+            {
+              index: 1,
+              name: "TIFF",
+            },
+          ],
+        },
+        id: 2,
+        name: "Astro img format",
+      },
+      {
+        gearMode: {
+          defaultValueIndex: 0,
+          values: [
+              {
+                index: 0,
+                name: "3",
+              },
+              {
+                index: 1,
+                name: "5",
+              },
+              {
+                index: 2,
+                name: "10",
+              },
+              {
+                index: 3,
+                name: "15",
+              },
+              {
+                index: 4,
+                name: "20",
+              },
+              {
+                index: 5,
+                name: "30",
+              },
+              {
+                index: 6,
+                name: "40",
+              },
+              {
+                index: 7,
+                name: "50",
+              },
+              {
+                index: 8,
+                name: "60",
+              },
+              {
+                index: 9,
+                name: "70",
+              },
+              {
+                index: 10,
+                name: "80",
+              },
+              {
+                index: 11,
+                name: "90",
+              },
+              {
+                index: 12,
+                name: "100",
+              },
+              {
+                index: 13,
+                name: "120",
+              },
+              {
+                index: 14,
+                name: "150",
+              },
+              {
+                index: 15,
+                name: "200",
+              },
+              {
+                index: 16,
+                name: "300",
+              },
+              {
+                index: 17,
+                name: "400",
+              },
+              {
+                index: 18,
+                name: "500",
+              },
+              {
+                index: 19,
+                name: "600",
+              },
+              {
+                index: 20,
+                name: "700",
+              },
+              {
+                index: 21,
+                name: "900",
+              },
+              {
+                index: 22,
+                name: "1000",
+              },
+          ],
+        },
+        id: 3,
+        name: "Count Burst",
+      },
+      {
+        gearMode: {
+          defaultValueIndex: 0,
+          values: [
+              {
+                index: 0,
+                name: "0.5 s",
+              },
+              {
+                index: 1,
+                name: "1 s",
+              },
+              {
+                index: 2,
+                name: "2 s",
+              },
+              {
+                index: 3,
+                name: "3 s",
+              },
+              {
+                index: 4,
+                name: "4 s",
+              },
+              {
+                index: 5,
+                name: "5 s",
+              },
+              {
+                index: 6,
+                name: "8 s",
+              },
+              {
+                index: 7,
+                name: "10 s",
+              },
+              {
+                index: 8,
+                name: "15 s",
+              },
+              {
+                index: 9,
+                name: "20 s",
+              },
+              {
+                index: 10,
+                name: "25 s",
+              },
+              {
+                index: 11,
+                name: "30 s",
+              },
+              {
+                index: 12,
+                name: "60 s",
+              },
+          ],
+        },
+        id: 4,
+        name: "Interval TimeLapse",
+      },
+      {
+        gearMode: {
+          defaultValueIndex: 0,
+          values: [
+              {
+                index: 0,
+                name: "∞",
+              },
+              {
+                index: 1,
+                name: "2 min",
+              },
+              {
+                index: 2,
+                name: "5 min",
+              },
+              {
+                index: 3,
+                name: "8 min",
+              },
+              {
+                index: 4,
+                name: "10 min",
+              },
+              {
+                index: 5,
+                name: "20 min",
+              },
+              {
+                index: 6,
+                name: "30 min",
+              },
+              {
+                index: 7,
+                name: "40 min",
+              },
+              {
+                index: 8,
+                name: "50 min",
+              },
+              {
+                index: 9,
+                name: "60 min",
+              },
+              {
+                index: 10,
+                name: "120 min",
+              },
+              {
+                index: 11,
+                name: "180 min",
+              },
+              {
+                index: 12,
+                name: "240 min",
+              },
+              {
+                index: 13,
+                name: "300 min",
+              },
+          ],
+        },
+        id: 5,
+        name: "Total Time TimeLapse",
+      },
+      {
+        autoMode: 0,
+        continueMode: {
+          defaultValue: 0,
+          max: 0,
+          min: 0,
+          step: 0,
+          valueType: 0,
+        },
+        defaultModeIndex: 0,
+        hasAuto: 0,
+        id: 6,
+        name: "Wide Exp Mode",
+        supportMode: [0],
+      },
+      {
+        autoMode: 0,
+        continueMode: {
+          defaultValue: 0,
+          max: 0,
+          min: 0,
+          step: 0,
+          valueType: 0,
+        },
+        defaultModeIndex: 0,
+        hasAuto: 0,
+        id: 7,
+        name: "Tele Exp Mode",
+        supportMode: [0],
+      },
+      {
+        gearMode: {
+          defaultValueIndex: 0,
+          values: [
+            {
+              index: 0,
+              name: "Stacked",
+            },
+            {
+              index: 1,
+              name: "Single",
+            },
+          ],
+        },
+        id: 8,
+        name: "Astro save format",
+      },
+      {
+        gearMode: {
+          defaultValueIndex: 0,
+          values: [
+              {
+                index: 0,
+                name: "Off",
+              },
+              {
+                index: 1,
+                name: "1 s",
+              },
+              {
+                index: 2,
+                name: "2 s",
+              },
+              {
+                index: 3,
+                name: "3 s",
+              },
+              {
+                index: 4,
+                name: "4 s",
+              },
+              {
+                index: 5,
+                name: "5 s",
+              },
+              {
+                index: 6,
+                name: "8 s",
+              },
+              {
+                index: 7,
+                name: "10 s",
+              },
+              {
+                index: 8,
+                name: "15 s",
+              },
+              {
+                index: 9,
+                name: "20 s",
+              },
+              {
+                index: 10,
+                name: "25 s",
+              },
+              {
+                index: 11,
+                name: "30 s",
+              },
+              {
+                index: 12,
+                name: "60 s",
+              },
+          ],
+        },
+        id: 9,
+        name: "Interval Burst",
+      },
+      {
+        gearMode: {
+          defaultValueIndex: 0,
+          values: [
+            {
+              index: 0,
+              name: "4K",
+            },
+            {
+              index: 1,
+              name: "2K",
+            },
+          ],
+        },
+        id: 10,
+        name: "Photo Resolution",
+      },
+      {
+        gearMode: {
+          defaultValueIndex: 0,
+          values: [
+            {
+              index: 0,
+              name: "30",
+            },
+            {
+              index: 1,
+              name: "60",
+            },
+          ],
+        },
+        id: 11,
+        name: "Video Frame Rate",
+      },
+      {
+        gearMode: {
+          defaultValueIndex: 0,
+          values: [
+            {
+              index: 0,
+              name: "2K",
+            },
+          ],
+        },
+        id: 12,
+        name: "Video Resolution",
+      },
+      {
+        gearMode: {
+          defaultValueIndex: 0,
+          values: [
+            {
+              index: 0,
+              name: "30",
+            },
+          ],
+        },
+        id: 13,
+        name: "Timelapse Frame Rate",
+      },
+      {
+        gearMode: {
+          defaultValueIndex: 1,
+          values: [
+            {
+              index: 0,
+              name: "ON",
+            },
+            {
+              index: 1,
+              name: "OFF",
+            },
+          ],
+        },
+        id: 14,
+        name: "Timelapse Acceleration",
+      },
+    ],
+  },
+};

--- a/src/lib/data_utils.ts
+++ b/src/lib/data_utils.ts
@@ -1,5 +1,6 @@
 import { data_dwarf2_config } from "@/lib/data_dwarf2_config";
 import { data_dwarf3_config } from "@/lib/data_dwarf3_config";
+import { data_dwarf_mini_config } from "@/lib/data_dwarf_mini_config";
 
 // Function to get the exposures from JSON data
 const getExposuresDwarf2 = () => {
@@ -26,10 +27,22 @@ const getExposuresDwarf3 = () => {
   return value ? value : false;
 };
 
+const getExposuresDwarfMini = () => {
+  let value;
+  let supportParam;
+  const camera = data_dwarf_mini_config.data.cameras.find(
+    (camera) => camera.id === 0
+  );
+  if (camera)
+    supportParam = camera.supportParams.find((param) => param.id === 0);
+  value = supportParam.gearMode;
+  return value ? value : false;
+};
+
 export const allowedExposures = {
   1: getExposuresDwarf2(),
   2: getExposuresDwarf3(),
-  4: getExposuresDwarf3(), // DWARF mini uses same sensor family as DWARF3
+  4: getExposuresDwarfMini(),
 };
 
 export const getExposureIndexDefault = (DwarfModelId = 1) => {
@@ -101,10 +114,22 @@ const getGainsDwarf3 = () => {
   return value ? value : false;
 };
 
+const getGainsDwarfMini = () => {
+  let value;
+  let supportParam;
+  const camera = data_dwarf_mini_config.data.cameras.find(
+    (camera) => camera.id === 0
+  );
+  if (camera)
+    supportParam = camera.supportParams.find((param) => param.id === 1);
+  value = supportParam.gearMode;
+  return value ? value : false;
+};
+
 export const allowedGains = {
   1: getGainsDwarf2(),
   2: getGainsDwarf3(),
-  4: getGainsDwarf3(),
+  4: getGainsDwarfMini(),
 };
 
 export const getGainNameByIndex = (index, DwarfModelId = 1) => {
@@ -152,10 +177,22 @@ const getWBColorTempDwarf3 = () => {
   return value ? value : false;
 };
 
+const getWBColorTempDwarfMini = () => {
+  let value;
+  let supportParam;
+  const camera = data_dwarf_mini_config.data.cameras.find(
+    (camera) => camera.id === 0
+  );
+  if (camera)
+    supportParam = camera.supportParams.find((param) => param.id === 2);
+  value = supportParam.gearMode;
+  return value ? value : false;
+};
+
 export const allowedWBColorTemp = {
   1: getWBColorTempDwarf2(),
   2: getWBColorTempDwarf3(),
-  4: getWBColorTempDwarf3(),
+  4: getWBColorTempDwarfMini(),
 };
 
 export const getWBColorTempValueByIndex = (index, DwarfModelId = 1) => {
@@ -197,10 +234,19 @@ const getCountBurstDwarf3 = () => {
   return value ? value : false;
 };
 
+const getCountBurstDwarfMini = () => {
+  let value;
+  const featureParam = data_dwarf_mini_config.data.featureParams.find(
+    (feature) => feature.id === 3
+  );
+  if (featureParam) value = featureParam.gearMode;
+  return value ? value : false;
+};
+
 export const allowedCountBurst = {
   1: getCountBurstDwarf2(),
   2: getCountBurstDwarf3(),
-  4: getCountBurstDwarf3(),
+  4: getCountBurstDwarfMini(),
 };
 
 export const getCountBurstValueByIndex = (index, DwarfModelId = 1) => {
@@ -242,10 +288,19 @@ const getCountIntervalDwarf3 = () => {
   return value ? value : false;
 };
 
+const getCountIntervalDwarfMini = () => {
+  let value;
+  const featureParam = data_dwarf_mini_config.data.featureParams.find(
+    (feature) => feature.id === 9
+  );
+  if (featureParam) value = featureParam.gearMode;
+  return value ? value : false;
+};
+
 export const allowedIntervalBurst = {
   1: getCountIntervalDwarf2(),
   2: getCountIntervalDwarf3(),
-  4: getCountIntervalDwarf3(),
+  4: getCountIntervalDwarfMini(),
 };
 
 export const getIntervalBurstValueByIndex = (index, DwarfModelId = 1) => {
@@ -287,10 +342,19 @@ const getIntervalTimeLapseDwarf3 = () => {
   return value ? value : false;
 };
 
+const getIntervalTimeLapseDwarfMini = () => {
+  let value;
+  const featureParam = data_dwarf_mini_config.data.featureParams.find(
+    (feature) => feature.id === 4
+  );
+  if (featureParam) value = featureParam.gearMode;
+  return value ? value : false;
+};
+
 export const allowedIntervalTimeLapse = {
   1: getIntervalTimeLapseDwarf2(),
   2: getIntervalTimeLapseDwarf3(),
-  4: getIntervalTimeLapseDwarf3(),
+  4: getIntervalTimeLapseDwarfMini(),
 };
 
 export const getIntervalTimeLapseValueByIndex = (index, DwarfModelId = 1) => {
@@ -333,10 +397,19 @@ const getTotalTimeTimeLapseDwarf3 = () => {
   return value ? value : false;
 };
 
+const getTotalTimeTimeLapseDwarfMini = () => {
+  let value;
+  const featureParam = data_dwarf_mini_config.data.featureParams.find(
+    (feature) => feature.id === 5
+  );
+  if (featureParam) value = featureParam.gearMode;
+  return value ? value : false;
+};
+
 export const allowedTotalTimeTimeLapse = {
   1: getTotalTimeTimeLapseDwarf2(),
   2: getTotalTimeTimeLapseDwarf3(),
-  4: getTotalTimeTimeLapseDwarf3(),
+  4: getTotalTimeTimeLapseDwarfMini(),
 };
 
 export const getTotalTimeTimeLapseValueByIndex = (index, DwarfModelId = 1) => {
@@ -385,10 +458,22 @@ const getIRDwarf3 = () => {
   return value ? value : false;
 };
 
+const getIRDwarfMini = () => {
+  let value;
+  let supportParam;
+  const camera = data_dwarf_mini_config.data.cameras.find(
+    (camera) => camera.id === 0
+  );
+  if (camera)
+    supportParam = camera.supportParams.find((param) => param.id === 8);
+  value = supportParam.gearMode;
+  return value ? value : false;
+};
+
 export const allowedIRs = {
   1: getIRDwarf2(),
   2: getIRDwarf3(),
-  4: getIRDwarf3(),
+  4: getIRDwarfMini(),
 };
 
 export const getIRNameByIndex = (index, DwarfModelId = 1) => {

--- a/src/lib/data_utils.ts
+++ b/src/lib/data_utils.ts
@@ -29,6 +29,7 @@ const getExposuresDwarf3 = () => {
 export const allowedExposures = {
   1: getExposuresDwarf2(),
   2: getExposuresDwarf3(),
+  4: getExposuresDwarf3(), // DWARF mini uses same sensor family as DWARF3
 };
 
 export const getExposureIndexDefault = (DwarfModelId = 1) => {
@@ -103,6 +104,7 @@ const getGainsDwarf3 = () => {
 export const allowedGains = {
   1: getGainsDwarf2(),
   2: getGainsDwarf3(),
+  4: getGainsDwarf3(),
 };
 
 export const getGainNameByIndex = (index, DwarfModelId = 1) => {
@@ -153,6 +155,7 @@ const getWBColorTempDwarf3 = () => {
 export const allowedWBColorTemp = {
   1: getWBColorTempDwarf2(),
   2: getWBColorTempDwarf3(),
+  4: getWBColorTempDwarf3(),
 };
 
 export const getWBColorTempValueByIndex = (index, DwarfModelId = 1) => {
@@ -197,6 +200,7 @@ const getCountBurstDwarf3 = () => {
 export const allowedCountBurst = {
   1: getCountBurstDwarf2(),
   2: getCountBurstDwarf3(),
+  4: getCountBurstDwarf3(),
 };
 
 export const getCountBurstValueByIndex = (index, DwarfModelId = 1) => {
@@ -241,6 +245,7 @@ const getCountIntervalDwarf3 = () => {
 export const allowedIntervalBurst = {
   1: getCountIntervalDwarf2(),
   2: getCountIntervalDwarf3(),
+  4: getCountIntervalDwarf3(),
 };
 
 export const getIntervalBurstValueByIndex = (index, DwarfModelId = 1) => {
@@ -285,6 +290,7 @@ const getIntervalTimeLapseDwarf3 = () => {
 export const allowedIntervalTimeLapse = {
   1: getIntervalTimeLapseDwarf2(),
   2: getIntervalTimeLapseDwarf3(),
+  4: getIntervalTimeLapseDwarf3(),
 };
 
 export const getIntervalTimeLapseValueByIndex = (index, DwarfModelId = 1) => {
@@ -330,6 +336,7 @@ const getTotalTimeTimeLapseDwarf3 = () => {
 export const allowedTotalTimeTimeLapse = {
   1: getTotalTimeTimeLapseDwarf2(),
   2: getTotalTimeTimeLapseDwarf3(),
+  4: getTotalTimeTimeLapseDwarf3(),
 };
 
 export const getTotalTimeTimeLapseValueByIndex = (index, DwarfModelId = 1) => {
@@ -381,6 +388,7 @@ const getIRDwarf3 = () => {
 export const allowedIRs = {
   1: getIRDwarf2(),
   2: getIRDwarf3(),
+  4: getIRDwarf3(),
 };
 
 export const getIRNameByIndex = (index, DwarfModelId = 1) => {

--- a/src/lib/data_wide_utils.ts
+++ b/src/lib/data_wide_utils.ts
@@ -1,5 +1,6 @@
 import { data_dwarf2_config } from "@/lib/data_dwarf2_config";
 import { data_dwarf3_config } from "@/lib/data_dwarf3_config";
+import { data_dwarf_mini_config } from "@/lib/data_dwarf_mini_config";
 
 // Function to get the exposures from JSON data
 const getWideExposuresDwarf2 = () => {
@@ -26,10 +27,22 @@ const getWideExposuresDwarf3 = () => {
   return value ? value : false;
 };
 
+const getWideExposuresDwarfMini = () => {
+  let value;
+  let supportParam;
+  const camera = data_dwarf_mini_config.data.cameras.find(
+    (camera) => camera.id === 1
+  );
+  if (camera)
+    supportParam = camera.supportParams.find((param) => param.id === 0);
+  if (supportParam) value = supportParam.gearMode;
+  return value ? value : false;
+};
+
 export const allowedWideExposures = {
   1: getWideExposuresDwarf2(),
   2: getWideExposuresDwarf3(),
-  4: getWideExposuresDwarf3(), // DWARF mini uses same sensor family as DWARF3
+  4: getWideExposuresDwarfMini(),
 };
 
 export const getWideExposureIndexDefault = (DwarfModelId = 1) => {
@@ -101,10 +114,22 @@ const getWideGainsDwarf3 = () => {
   return value ? value : false;
 };
 
+const getWideGainsDwarfMini = () => {
+  let value;
+  let supportParam;
+  const camera = data_dwarf_mini_config.data.cameras.find(
+    (camera) => camera.id === 1
+  );
+  if (camera)
+    supportParam = camera.supportParams.find((param) => param.id === 1);
+  if (supportParam) value = supportParam.gearMode;
+  return value ? value : false;
+};
+
 export const allowedWideGains = {
   1: getWideGainsDwarf2(),
   2: getWideGainsDwarf3(),
-  4: getWideGainsDwarf3(),
+  4: getWideGainsDwarfMini(),
 };
 
 export const getWideGainNameByIndex = (index, DwarfModelId = 1) => {
@@ -155,10 +180,22 @@ const getWideWBColorTempDwarf3 = () => {
   return value ? value : false;
 };
 
+const getWideWBColorTempDwarfMini = () => {
+  let value;
+  let supportParam;
+  const camera = data_dwarf_mini_config.data.cameras.find(
+    (camera) => camera.id === 1
+  );
+  if (camera)
+    supportParam = camera.supportParams.find((param) => param.id === 2);
+  value = supportParam.gearMode;
+  return value ? value : false;
+};
+
 export const allowedWideWBColorTemp = {
   1: getWideWBColorTempDwarf2(),
   2: getWideWBColorTempDwarf3(),
-  4: getWideWBColorTempDwarf3(),
+  4: getWideWBColorTempDwarfMini(),
 };
 
 export const getWideWBColorTempValueByIndex = (index, DwarfModelId = 1) => {

--- a/src/lib/data_wide_utils.ts
+++ b/src/lib/data_wide_utils.ts
@@ -29,6 +29,7 @@ const getWideExposuresDwarf3 = () => {
 export const allowedWideExposures = {
   1: getWideExposuresDwarf2(),
   2: getWideExposuresDwarf3(),
+  4: getWideExposuresDwarf3(), // DWARF mini uses same sensor family as DWARF3
 };
 
 export const getWideExposureIndexDefault = (DwarfModelId = 1) => {
@@ -103,6 +104,7 @@ const getWideGainsDwarf3 = () => {
 export const allowedWideGains = {
   1: getWideGainsDwarf2(),
   2: getWideGainsDwarf3(),
+  4: getWideGainsDwarf3(),
 };
 
 export const getWideGainNameByIndex = (index, DwarfModelId = 1) => {
@@ -156,6 +158,7 @@ const getWideWBColorTempDwarf3 = () => {
 export const allowedWideWBColorTemp = {
   1: getWideWBColorTempDwarf2(),
   2: getWideWBColorTempDwarf3(),
+  4: getWideWBColorTempDwarf3(),
 };
 
 export const getWideWBColorTempValueByIndex = (index, DwarfModelId = 1) => {

--- a/src/lib/get_dwarf_type.ts
+++ b/src/lib/get_dwarf_type.ts
@@ -53,6 +53,7 @@ const getDeviceInfo = async (
         if (result && result.data) {
           const id = result.data.deviceId;
           const uid = result.data.deviceName
+            .replace("DWARF_MINI_", "")
             .replace("DWARF3_", "")
             .replace("DWARF_", "");
 
@@ -193,6 +194,7 @@ const getDwarfType = async (
   let folderResponse;
   const dwarfIIUrl = `http://${IPDwarf}/sdcard/DWARF_II/Astronomy/`;
   const dwarf3Url = `http://${IPDwarf}/DWARF3/Astronomy/`;
+  const dwarfMiniUrl = `http://${IPDwarf}/DWARF_mini/Astronomy/`;
 
   try {
     // First attempt to fetch Dwarf II
@@ -211,30 +213,47 @@ const getDwarfType = async (
       // Dwarf II found
       console.log("Detected device type: Dwarf II");
       return 1;
-    } else {
-      // If not OK, try Dwarf 3
-      proxyUrl = `${getProxyUrl(connectionCtx)}?target=${encodeURIComponent(
-        dwarf3Url
-      )}`;
-      folderResponse = await fetch(proxyUrl, {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        redirect: "follow",
-      });
-
-      if (folderResponse.ok) {
-        // Dwarf 3 found
-        console.log("Detected device type: Dwarf 3");
-        return 2;
-      } else {
-        console.error(
-          "Error fetching folder from both Dwarf II and Dwarf 3:",
-          folderResponse.statusText
-        );
-      }
     }
+
+    // Try Dwarf 3
+    proxyUrl = `${getProxyUrl(connectionCtx)}?target=${encodeURIComponent(
+      dwarf3Url
+    )}`;
+    folderResponse = await fetch(proxyUrl, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      redirect: "follow",
+    });
+
+    if (folderResponse.ok) {
+      // Dwarf 3 found
+      console.log("Detected device type: Dwarf 3");
+      return 2;
+    }
+
+    // Try Dwarf Mini
+    proxyUrl = `${getProxyUrl(connectionCtx)}?target=${encodeURIComponent(
+      dwarfMiniUrl
+    )}`;
+    folderResponse = await fetch(proxyUrl, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      redirect: "follow",
+    });
+
+    if (folderResponse.ok) {
+      console.log("Detected device type: Dwarf Mini");
+      return 4;
+    }
+
+    console.error(
+      "Error fetching folder from Dwarf II, Dwarf 3, and Dwarf Mini:",
+      folderResponse.statusText
+    );
   } catch (error) {
     if (error instanceof Error) {
       console.error("Error checking dwarf info:", error.message);


### PR DESCRIPTION
## Summary

- Add deviceId=4 entries to all 8 camera parameter maps in `data_utils.ts` to prevent runtime crashes when DWARF mini connects
- Add `/DWARF_mini/Astronomy/` folder detection path in `getDwarfType()` fallback
- Handle `DWARF_MINI_` prefix in device name UID parsing
- Export and reuse `getDeviceName()` for device display instead of hardcoded ternary

Closes #20, #21, #22, #23

## Test plan

- [ ] Connect to DWARF mini and verify camera settings page loads without crash
- [ ] Verify device is detected as "Dwarf Mini" in UI
- [ ] Verify exposure/gain/WB dropdowns populate correctly
- [ ] Verify camera stream URLs work for DWARF mini
- [ ] Verify DWARF II and DWARF3 are not affected (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)