### PR TITLE
feat: add DWARF device auto-discovery

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -578,6 +578,78 @@ app.get("/getLocalIP", async (req, res) => {
   res.status(200).json({ ips: getLocalIPAddress() });
 });
 
+app.get("/discover", async (req, res) => {
+  console.log("Discover devices is running");
+
+  function getSubnetBase(ip: string): string | null {
+    const parts = ip.split(".");
+    if (parts.length !== 4) return null;
+    return parts.slice(0, 3).join(".");
+  }
+
+  async function probeDevice(
+    ip: string,
+    timeout = 500
+  ): Promise<{ ip: string; deviceId: string; deviceName: string } | null> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
+    try {
+      const response = await fetch(`http://${ip}:8082/deviceInfo`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+        signal: controller.signal,
+      });
+      if (!response.ok) return null;
+      const data = (await response.json()) as Record<string, unknown>;
+      const deviceId = data.id ?? data.deviceId ?? "";
+      const deviceName = data.name ?? data.deviceName ?? ip;
+      return {
+        ip,
+        deviceId: String(deviceId),
+        deviceName: String(deviceName),
+      };
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  try {
+    const localIPs = getLocalIPAddress();
+    const subnetBase =
+      localIPs.length > 0 ? getSubnetBase(localIPs[0]) : null;
+    if (!subnetBase) {
+      return res.status(200).json({ devices: [] });
+    }
+
+    const ips = Array.from(
+      { length: 254 },
+      (_, i) => `${subnetBase}.${i + 1}`
+    );
+    const devices: { ip: string; deviceId: string; deviceName: string }[] = [];
+    const batchSize = 50;
+
+    for (let i = 0; i < ips.length; i += batchSize) {
+      const batch = ips.slice(i, i + batchSize);
+      const results = await Promise.all(
+        batch.map((ip) => probeDevice(ip, 500))
+      );
+      for (const result of results) {
+        if (result) devices.push(result);
+      }
+    }
+
+    res.status(200).json({ devices });
+  } catch (error) {
+    console.error("Discovery failed:", error);
+    res
+      .status(500)
+      .json({ error: (error as Error).message || "Discovery failed" });
+  }
+});
+
 app.use((req, res, next) => {
   console.debug(`📥 Incoming Request: ${req.method} ${req.originalUrl}`);
   next();

--- a/server/server.ts
+++ b/server/server.ts
@@ -602,8 +602,11 @@ app.get("/discover", async (req, res) => {
       });
       if (!response.ok) return null;
       const data = (await response.json()) as Record<string, unknown>;
-      const deviceId = data.id ?? data.deviceId ?? "";
-      const deviceName = data.name ?? data.deviceName ?? ip;
+      // DWARF API returns { code, data: { deviceId, deviceName, ... } }
+      const inner = data?.data as Record<string, unknown> | undefined;
+      if (!inner) return null;
+      const deviceId = inner.deviceId ?? inner.id ?? "";
+      const deviceName = inner.deviceName ?? inner.name ?? ip;
       return {
         ip,
         deviceId: String(deviceId),

--- a/src/__tests__/lib/discover_devices.test.ts
+++ b/src/__tests__/lib/discover_devices.test.ts
@@ -1,0 +1,44 @@
+import { getSubnetBase } from "@/lib/discover_devices";
+
+describe("getSubnetBase", () => {
+  it("extracts subnet base from a valid IP", () => {
+    expect(getSubnetBase("192.168.1.42")).toBe("192.168.1");
+  });
+
+  it("extracts subnet base from another valid IP", () => {
+    expect(getSubnetBase("10.0.0.1")).toBe("10.0.0");
+  });
+
+  it("handles IP with high octets", () => {
+    expect(getSubnetBase("172.16.255.254")).toBe("172.16.255");
+  });
+
+  it("returns null for IP with too few octets", () => {
+    expect(getSubnetBase("192.168.1")).toBeNull();
+  });
+
+  it("returns null for IP with too many octets", () => {
+    expect(getSubnetBase("192.168.1.1.1")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(getSubnetBase("")).toBeNull();
+  });
+
+  it("returns null for non-numeric octets", () => {
+    expect(getSubnetBase("abc.def.ghi.jkl")).toBeNull();
+  });
+
+  it("returns null for octet out of range (>255)", () => {
+    expect(getSubnetBase("192.168.1.256")).toBeNull();
+  });
+
+  it("returns null for negative octet", () => {
+    expect(getSubnetBase("192.168.-1.1")).toBeNull();
+  });
+
+  it("handles boundary values (0 and 255)", () => {
+    expect(getSubnetBase("0.0.0.0")).toBe("0.0.0");
+    expect(getSubnetBase("255.255.255.255")).toBe("255.255.255");
+  });
+});

--- a/src/components/setup/ConnectDwarf.tsx
+++ b/src/components/setup/ConnectDwarf.tsx
@@ -9,6 +9,13 @@ import { ConnectionContext } from "@/stores/ConnectionContext";
 import { saveIPDwarfDB, saveIPConnectDB } from "@/db/db_utils";
 
 import { connectionHandler } from "@/lib/connect_utils";
+import { getServerUrl } from "@/lib/get_proxy_url";
+
+interface DiscoveredDevice {
+  ip: string;
+  deviceId: string;
+  deviceName: string;
+}
 
 const DwarfClientID_original = "0000DAF2-0000-1000-8000-00805F9B34FB";
 const DwarfClientID_base = "0000DAF2-0000-1000-8000-00805F9B35";
@@ -31,6 +38,13 @@ export default function ConnectDwarf() {
   const [goLive, setGoLive] = useState(false);
   const [errorTxt, setErrorTxt] = useState("");
   const [debouncedValue, setDebouncedValue] = useState(""); // Debounced value
+
+  const [discovering, setDiscovering] = useState(false);
+  const [discoveredDevices, setDiscoveredDevices] = useState<
+    DiscoveredDevice[]
+  >([]);
+  const [discoverError, setDiscoverError] = useState("");
+  const [hasDiscovered, setHasDiscovered] = useState(false);
 
   // Debouncing logic
   useEffect(() => {
@@ -216,6 +230,40 @@ export default function ConnectDwarf() {
     connectionCtx.setTypeNameDwarf("");
   };
 
+  async function handleDiscover() {
+    setDiscovering(true);
+    setDiscoverError("");
+    setDiscoveredDevices([]);
+    setHasDiscovered(false);
+
+    try {
+      const serverUrl = getServerUrl();
+      const url = serverUrl.includes("api")
+        ? "/api/discover"
+        : serverUrl + "/discover";
+
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      setDiscoveredDevices(data.devices || []);
+      setHasDiscovered(true);
+    } catch (err) {
+      console.error("Discovery failed:", err);
+      setDiscoverError((err as Error).message || "Discovery failed");
+      setHasDiscovered(true);
+    } finally {
+      setDiscovering(false);
+    }
+  }
+
+  function selectDevice(device: DiscoveredDevice) {
+    setIpValue(device.ip);
+    connectionCtx.setIPDwarf(device.ip);
+    saveIPDwarfDB(device.ip);
+  }
+
   const { t } = useTranslation();
   // eslint-disable-next-line no-unused-vars
   const [selectedLanguage, setSelectedLanguage] = useState<string>("en");
@@ -325,8 +373,62 @@ export default function ConnectDwarf() {
               onChange={(e) => ipHandler(e)}
               disabled={ipAuto}
             />
+            <button
+              type="button"
+              className="btn btn-more02 ms-2"
+              onClick={handleDiscover}
+              disabled={discovering}
+            >
+              <i className="bi bi-search" />{" "}
+              {discovering ? t("pDiscovering") : t("pDiscoverDevices")}
+            </button>
           </div>
         </div>
+        {hasDiscovered && !discoverError && discoveredDevices.length === 0 && (
+          <div className="row mb-3">
+            <div className="col-lg-2 col-md-3"></div>
+            <div className="col">
+              <span className="text-warning">{t("pDiscoverNoDevices")}</span>
+            </div>
+          </div>
+        )}
+        {discoverError && (
+          <div className="row mb-3">
+            <div className="col-lg-2 col-md-3"></div>
+            <div className="col">
+              <span className="text-danger">{t("pDiscoverError")}</span>
+            </div>
+          </div>
+        )}
+        {discoveredDevices.length > 0 && (
+          <div className="row mb-3">
+            <div className="col-lg-2 col-md-3"></div>
+            <div className="col">
+              <p>
+                {t("pDiscoverFound", { count: discoveredDevices.length })}
+              </p>
+              <ul className="list-group">
+                {discoveredDevices.map((device) => (
+                  <li
+                    key={device.ip}
+                    className="list-group-item d-flex justify-content-between align-items-center"
+                  >
+                    <span>
+                      <strong>{device.deviceName}</strong> — {device.ip}
+                    </span>
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-more02"
+                      onClick={() => selectDevice(device)}
+                    >
+                      {t("pDiscoverSelect")}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        )}
         <button type="submit" className="btn btn-more02 me-3">
           <i className="icon-wifi" /> {t("pConnect")}
         </button>{" "}

--- a/src/components/setup/ConnectDwarf.tsx
+++ b/src/components/setup/ConnectDwarf.tsx
@@ -9,7 +9,7 @@ import { ConnectionContext } from "@/stores/ConnectionContext";
 import { saveIPDwarfDB, saveIPConnectDB } from "@/db/db_utils";
 
 import { connectionHandler } from "@/lib/connect_utils";
-import { getServerUrl } from "@/lib/get_proxy_url";
+import { getProxyUrl } from "@/lib/get_proxy_url";
 
 interface DiscoveredDevice {
   ip: string;
@@ -237,10 +237,10 @@ export default function ConnectDwarf() {
     setHasDiscovered(false);
 
     try {
-      const serverUrl = getServerUrl();
-      const url = serverUrl.includes("api")
+      const proxyUrl = getProxyUrl(connectionCtx);
+      const url = proxyUrl?.includes("api")
         ? "/api/discover"
-        : serverUrl + "/discover";
+        : proxyUrl + "/discover";
 
       const response = await fetch(url);
       if (!response.ok) {

--- a/src/lib/discover_devices.ts
+++ b/src/lib/discover_devices.ts
@@ -1,0 +1,91 @@
+import { getLocalIPAddress } from "@/lib/getLocalIp";
+
+export interface DiscoveredDevice {
+  ip: string;
+  deviceId: string;
+  deviceName: string;
+}
+
+/**
+ * Extract subnet base from an IP address.
+ * e.g. "192.168.1.42" → "192.168.1"
+ */
+export function getSubnetBase(ip: string): string | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  if (parts.some((p) => !/^\d{1,3}$/.test(p))) return null;
+  const nums = parts.map(Number);
+  if (nums.some((n) => n < 0 || n > 255)) return null;
+  return parts.slice(0, 3).join(".");
+}
+
+/**
+ * Probe a single IP for a DWARF device via POST /deviceInfo on port 8082.
+ * Returns device info or null if unreachable / not a DWARF.
+ */
+export async function probeDevice(
+  ip: string,
+  timeout = 500
+): Promise<DiscoveredDevice | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const res = await fetch(`http://${ip}:8082/deviceInfo`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+      signal: controller.signal,
+    });
+
+    if (!res.ok) return null;
+
+    const data = await res.json();
+    // DWARF devices return an object with id/name fields
+    const deviceId = data.id ?? data.deviceId ?? "";
+    const deviceName = data.name ?? data.deviceName ?? ip;
+
+    return { ip, deviceId: String(deviceId), deviceName: String(deviceName) };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Scan all 254 hosts on a /24 subnet for DWARF devices.
+ * Uses batched parallel requests to limit concurrency.
+ */
+export async function discoverDevices(
+  subnetBase?: string,
+  batchSize = 50,
+  timeout = 500
+): Promise<DiscoveredDevice[]> {
+  // Auto-detect subnet from local IP if not provided
+  if (!subnetBase) {
+    const localIPs = getLocalIPAddress();
+    if (localIPs.length > 0) {
+      subnetBase = getSubnetBase(localIPs[0]) ?? undefined;
+    }
+  }
+  if (!subnetBase) {
+    return [];
+  }
+
+  const ips = Array.from({ length: 254 }, (_, i) => `${subnetBase}.${i + 1}`);
+  const devices: DiscoveredDevice[] = [];
+
+  // Process in batches to limit concurrency
+  for (let i = 0; i < ips.length; i += batchSize) {
+    const batch = ips.slice(i, i + batchSize);
+    const results = await Promise.all(
+      batch.map((ip) => probeDevice(ip, timeout))
+    );
+    for (const result of results) {
+      if (result) devices.push(result);
+    }
+  }
+
+  return devices;
+}

--- a/src/lib/discover_devices.ts
+++ b/src/lib/discover_devices.ts
@@ -41,9 +41,12 @@ export async function probeDevice(
     if (!res.ok) return null;
 
     const data = await res.json();
-    // DWARF devices return an object with id/name fields
-    const deviceId = data.id ?? data.deviceId ?? "";
-    const deviceName = data.name ?? data.deviceName ?? ip;
+    // DWARF API returns { code, data: { deviceId, deviceName, ... } }
+    const inner = data?.data;
+    if (!inner) return null;
+
+    const deviceId = inner.deviceId ?? inner.id ?? "";
+    const deviceName = inner.deviceName ?? inner.name ?? ip;
 
     return { ip, deviceId: String(deviceId), deviceName: String(deviceName) };
   } catch {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -443,5 +443,11 @@
   "cAstroWeatherTemperature": "Temperatur:",
   "cAstroWeatherWindSpeed": "Windgeschwindigkeit:",
   "cAstroWeatherHumidity": "Luftfeuchtigkeit:",
-  "cAstroWeatherDewPoint": "Taupunkt:"
+  "cAstroWeatherDewPoint": "Taupunkt:",
+  "pDiscoverDevices": "Geräte erkennen",
+  "pDiscovering": "Netzwerk wird gescannt...",
+  "pDiscoverNoDevices": "Keine DWARF-Geräte gefunden. Stellen Sie sicher, dass Ihr Gerät eingeschaltet und mit demselben Netzwerk verbunden ist.",
+  "pDiscoverFound": "{{count}} Gerät(e) gefunden:",
+  "pDiscoverSelect": "Auswählen",
+  "pDiscoverError": "Erkennung fehlgeschlagen. Überprüfen Sie Ihre Netzwerkverbindung."
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -443,5 +443,11 @@
   "cAstroWeatherTemperature": "Temperature:",
   "cAstroWeatherWindSpeed": "Wind speed:",
   "cAstroWeatherHumidity": "Humidity:",
-  "cAstroWeatherDewPoint": "Dew point:"
+  "cAstroWeatherDewPoint": "Dew point:",
+  "pDiscoverDevices": "Discover Devices",
+  "pDiscovering": "Scanning network...",
+  "pDiscoverNoDevices": "No DWARF devices found. Ensure your device is powered on and connected to the same network.",
+  "pDiscoverFound": "{{count}} device(s) found:",
+  "pDiscoverSelect": "Select",
+  "pDiscoverError": "Discovery failed. Check your network connection."
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -443,5 +443,11 @@
   "cAstroWeatherTemperature": "Temperatura:",
   "cAstroWeatherWindSpeed": "Velocidad del viento:",
   "cAstroWeatherHumidity": "Humedad:",
-  "cAstroWeatherDewPoint": "Punto de rocío:"
+  "cAstroWeatherDewPoint": "Punto de rocío:",
+  "pDiscoverDevices": "Detectar dispositivos",
+  "pDiscovering": "Escaneando red...",
+  "pDiscoverNoDevices": "No se encontraron dispositivos DWARF. Asegúrese de que su dispositivo esté encendido y conectado a la misma red.",
+  "pDiscoverFound": "{{count}} dispositivo(s) encontrado(s):",
+  "pDiscoverSelect": "Seleccionar",
+  "pDiscoverError": "La detección falló. Verifique su conexión de red."
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -443,5 +443,11 @@
   "cAstroWeatherTemperature": "Température :",
   "cAstroWeatherWindSpeed": "Vitesse du vent :",
   "cAstroWeatherHumidity": "Humidité :",
-  "cAstroWeatherDewPoint": "Point de rosée :"
+  "cAstroWeatherDewPoint": "Point de rosée :",
+  "pDiscoverDevices": "Détecter les appareils",
+  "pDiscovering": "Scan du réseau...",
+  "pDiscoverNoDevices": "Aucun appareil DWARF trouvé. Vérifiez que votre appareil est allumé et connecté au même réseau.",
+  "pDiscoverFound": "{{count}} appareil(s) trouvé(s) :",
+  "pDiscoverSelect": "Sélectionner",
+  "pDiscoverError": "La détection a échoué. Vérifiez votre connexion réseau."
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -443,5 +443,11 @@
   "cAstroWeatherTemperature": "Temperatura:",
   "cAstroWeatherWindSpeed": "Velocità del vento:",
   "cAstroWeatherHumidity": "Umidità:",
-  "cAstroWeatherDewPoint": "Punto di rugiada:"
+  "cAstroWeatherDewPoint": "Punto di rugiada:",
+  "pDiscoverDevices": "Rileva dispositivi",
+  "pDiscovering": "Scansione della rete...",
+  "pDiscoverNoDevices": "Nessun dispositivo DWARF trovato. Assicurati che il dispositivo sia acceso e connesso alla stessa rete.",
+  "pDiscoverFound": "{{count}} dispositivo/i trovato/i:",
+  "pDiscoverSelect": "Seleziona",
+  "pDiscoverError": "Rilevamento fallito. Controlla la connessione di rete."
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -443,5 +443,11 @@
   "cAstroWeatherTemperature": "気温:",
   "cAstroWeatherWindSpeed": "風速:",
   "cAstroWeatherHumidity": "湿度:",
-  "cAstroWeatherDewPoint": "露点:"
+  "cAstroWeatherDewPoint": "露点:",
+  "pDiscoverDevices": "デバイスを検出",
+  "pDiscovering": "ネットワークをスキャン中...",
+  "pDiscoverNoDevices": "DWARFデバイスが見つかりませんでした。デバイスの電源が入っていて同じネットワークに接続されていることを確認してください。",
+  "pDiscoverFound": "{{count}} 台のデバイスが見つかりました:",
+  "pDiscoverSelect": "選択",
+  "pDiscoverError": "検出に失敗しました。ネットワーク接続を確認してください。"
 }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -443,5 +443,11 @@
   "cAstroWeatherTemperature": "Temperatuur:",
   "cAstroWeatherWindSpeed": "Windsnelheid:",
   "cAstroWeatherHumidity": "Luchtvochtigheid:",
-  "cAstroWeatherDewPoint": "Dauwpunt:"
+  "cAstroWeatherDewPoint": "Dauwpunt:",
+  "pDiscoverDevices": "Apparaten detecteren",
+  "pDiscovering": "Netwerk scannen...",
+  "pDiscoverNoDevices": "Geen DWARF-apparaten gevonden. Zorg ervoor dat uw apparaat is ingeschakeld en verbonden met hetzelfde netwerk.",
+  "pDiscoverFound": "{{count}} apparaat/apparaten gevonden:",
+  "pDiscoverSelect": "Selecteren",
+  "pDiscoverError": "Detectie mislukt. Controleer uw netwerkverbinding."
 }

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -443,5 +443,11 @@
   "cAstroWeatherTemperature": "Temperatura:",
   "cAstroWeatherWindSpeed": "Prędkość wiatru:",
   "cAstroWeatherHumidity": "Wilgotność:",
-  "cAstroWeatherDewPoint": "Punkt rosy:"
+  "cAstroWeatherDewPoint": "Punkt rosy:",
+  "pDiscoverDevices": "Wykryj urządzenia",
+  "pDiscovering": "Skanowanie sieci...",
+  "pDiscoverNoDevices": "Nie znaleziono urządzeń DWARF. Upewnij się, że urządzenie jest włączone i podłączone do tej samej sieci.",
+  "pDiscoverFound": "Znaleziono {{count}} urządzenie/urządzeń:",
+  "pDiscoverSelect": "Wybierz",
+  "pDiscoverError": "Wykrywanie nie powiodło się. Sprawdź połączenie sieciowe."
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -443,5 +443,11 @@
   "cAstroWeatherTemperature": "Temperatura:",
   "cAstroWeatherWindSpeed": "Velocidade do vento:",
   "cAstroWeatherHumidity": "Umidade:",
-  "cAstroWeatherDewPoint": "Ponto de orvalho:"
+  "cAstroWeatherDewPoint": "Ponto de orvalho:",
+  "pDiscoverDevices": "Detectar dispositivos",
+  "pDiscovering": "Escaneando rede...",
+  "pDiscoverNoDevices": "Nenhum dispositivo DWARF encontrado. Verifique se o dispositivo está ligado e conectado à mesma rede.",
+  "pDiscoverFound": "{{count}} dispositivo(s) encontrado(s):",
+  "pDiscoverSelect": "Selecionar",
+  "pDiscoverError": "A detecção falhou. Verifique sua conexão de rede."
 }

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -443,5 +443,11 @@
   "cAstroWeatherTemperature": "温度：",
   "cAstroWeatherWindSpeed": "风速：",
   "cAstroWeatherHumidity": "湿度：",
-  "cAstroWeatherDewPoint": "露点："
+  "cAstroWeatherDewPoint": "露点：",
+  "pDiscoverDevices": "检测设备",
+  "pDiscovering": "正在扫描网络...",
+  "pDiscoverNoDevices": "未找到DWARF设备。请确保设备已开机并连接到同一网络。",
+  "pDiscoverFound": "找到 {{count}} 个设备：",
+  "pDiscoverSelect": "选择",
+  "pDiscoverError": "检测失败。请检查网络连接。"
 }

--- a/src/pages/api/discover.ts
+++ b/src/pages/api/discover.ts
@@ -1,0 +1,22 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { discoverDevices } from "@/lib/discover_devices";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  console.log("API discover is running");
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method Not Allowed" });
+  }
+
+  try {
+    const devices = await discoverDevices();
+    return res.status(200).json({ devices });
+  } catch (error) {
+    console.error("Discovery failed:", error);
+    return res
+      .status(500)
+      .json({ error: (error as Error).message || "Discovery failed" });
+  }
+}


### PR DESCRIPTION
## Summary

- Add subnet scan to auto-discover DWARF devices on the local network
- Probe all 254 IPs on the /24 subnet via `POST :8082/deviceInfo` (50 concurrent, 500ms timeout, ~3s total)
- Add "Discover Devices" button in the Connect to Dwarf section — detected devices appear in a list, click to auto-fill IP

## Changes

- **New** `src/lib/discover_devices.ts` — core scan logic (getSubnetBase, probeDevice, discoverDevices)
- **New** `src/pages/api/discover.ts` — Next.js API route `GET /api/discover`
- **New** `src/__tests__/lib/discover_devices.test.ts` — unit tests for getSubnetBase (10 tests)
- **Modified** `server/server.ts` — Express `/discover` endpoint (before catch-all)
- **Modified** `src/components/setup/ConnectDwarf.tsx` — discover button + device list UI
- **Modified** 10 locale files — 6 i18n keys added per locale

Closes #28

## Test plan

- [x] `TZ=Europe/Paris npx jest` — 300 tests pass (15 suites)
- [x] `npx next build` — build succeeds
- [ ] Manual: click "Discover Devices" with a DWARF on the same network → device appears in list
- [ ] Manual: click "Select" on a discovered device → IP field auto-filled → connect works

🤖 Generated with [Claude Code](https://claude.com/claude-code)